### PR TITLE
fix: crashes, hangs & test-suite data loss (bug-hunt PR-1/3)

### DIFF
--- a/Sources/MacControlMCP/AXObserverBridge.swift
+++ b/Sources/MacControlMCP/AXObserverBridge.swift
@@ -186,17 +186,24 @@ public final class AXObserverBridge: @unchecked Sendable {
                 return
             }
 
-            // 4. Attach the observer's source to our dedicated runloop.
+            // 4. Get the observer's runloop source and stash cleanup BEFORE
+            // arming it. `AXObserverGetRunLoopSource` only fetches the source;
+            // no callback can be delivered until the source is added to a
+            // runloop (step 5). If we added the source first, the AX callback
+            // could fire on the runloop thread and call `box.resume()` before
+            // `box.cleanup` was set — the box would already be resolved, so
+            // cleanup never ran, leaking the observer, its source, and the
+            // retained refcon forever.
             let source = AXObserverGetRunLoopSource(observer)
-            CFRunLoopAddSource(self.runloop, source, .defaultMode)
-
-            // 5. Stash cleanup. Whichever resolves first — callback or
-            // timeout — runs this once and nils it out.
             box.cleanup = { [runloop = self.runloop] in
                 CFRunLoopRemoveSource(runloop, source, .defaultMode)
                 AXObserverRemoveNotification(observer, element, notification as CFString)
                 Unmanaged<AXObserverWait>.fromOpaque(refcon).release()
             }
+
+            // 5. Arm it: attach the source so the callback can be delivered.
+            //    cleanup is already in place, so an immediate fire is safe.
+            CFRunLoopAddSource(self.runloop, source, .defaultMode)
 
             // 6. Arm the timeout on a global queue independent of the AX
             // runloop. This is fire-and-forget; `box.resume` is idempotent.

--- a/Sources/MacControlMCP/AXSnapshotController.swift
+++ b/Sources/MacControlMCP/AXSnapshotController.swift
@@ -69,7 +69,8 @@ actor AXSnapshotController {
     func capture(pid: pid_t, maxDepth: Int = 12) -> SnapshotTaken {
         let root = AXUIElementCreateApplication(pid)
         var flat: [String: NodeSnapshot] = [:]
-        walk(element: root, depth: 0, maxDepth: maxDepth, into: &flat)
+        let deadline = Date().addingTimeInterval(5.0)
+        walk(element: root, depth: 0, maxDepth: maxDepth, into: &flat, deadline: deadline)
 
         let id = "snap_" + String(UUID().uuidString.prefix(12)).lowercased()
         let now = Date()
@@ -133,9 +134,15 @@ actor AXSnapshotController {
         element: AXUIElement,
         depth: Int,
         maxDepth: Int,
-        into flat: inout [String: NodeSnapshot]
+        into flat: inout [String: NodeSnapshot],
+        deadline: Date,
+        nodeCap: Int = 5000
     ) {
         if depth > maxDepth { return }
+        // Wall-clock + node-count budget: without it, ax_snapshot_capture on
+        // a large app blocks the server for tens of seconds (each attribute
+        // read is an IPC round trip). Matches the AX walkers' 5 s / 5000 cap.
+        if Date() >= deadline || flat.count >= nodeCap { return }
         let key = String(CFHash(element), radix: 16)
         if flat[key] != nil { return } // already visited (cycle)
 
@@ -158,7 +165,8 @@ actor AXSnapshotController {
         let res = AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &raw)
         if res == .success, let children = raw as? [AXUIElement] {
             for c in children {
-                walk(element: c, depth: depth + 1, maxDepth: maxDepth, into: &flat)
+                if Date() >= deadline || flat.count >= nodeCap { return }
+                walk(element: c, depth: depth + 1, maxDepth: maxDepth, into: &flat, deadline: deadline, nodeCap: nodeCap)
             }
         }
     }

--- a/Sources/MacControlMCP/AccessibilityController.swift
+++ b/Sources/MacControlMCP/AccessibilityController.swift
@@ -289,9 +289,23 @@ actor AccessibilityController {
         case clipboard  // paste events only
         case keys       // CGEvent unicode only
         case ax         // AX set_value only
+
+        /// Strategy used when a caller omits `strategy`. `auto` tries
+        /// clipboard → keys → ax for event fidelity on React/Angular SPAs.
+        /// Single source of truth so the default can't drift silently.
+        static let `default`: TypeStrategy = .auto
+
+        /// Resolve a raw tool argument to a concrete strategy.
+        /// - `nil`/empty (argument omitted) → `.default`.
+        /// - a known name (case-insensitive) → that strategy.
+        /// - an unknown non-empty string → `nil` (caller reports an error).
+        static func resolve(argument raw: String?) -> TypeStrategy? {
+            guard let raw, !raw.isEmpty else { return .default }
+            return TypeStrategy(rawValue: raw.lowercased())
+        }
     }
 
-    func typeText(text: String, strategy: TypeStrategy = .auto) async -> TypeTextResult {
+    func typeText(text: String, strategy: TypeStrategy = .default) async -> TypeTextResult {
         switch strategy {
         case .ax:
             return setFocusedElementValue(text)

--- a/Sources/MacControlMCP/AccessibilityController.swift
+++ b/Sources/MacControlMCP/AccessibilityController.swift
@@ -157,8 +157,9 @@ actor AccessibilityController {
         let root = AXUIElementCreateApplication(pid)
         var visited = Set<AXKey>()
         var output: [ElementInfo] = []
+        let deadline = Date().addingTimeInterval(5.0)
 
-        _ = walk(element: root, depth: 0, maxDepth: max(1, maxDepth), visited: &visited) { element, depth, role in
+        _ = walk(element: root, depth: 0, maxDepth: max(1, maxDepth), visited: &visited, deadline: deadline) { element, depth, role in
             guard self.actionableRoles.contains(role) else { return false }
             output.append(self.buildElementInfo(element: element, depth: depth, cachedRole: role))
             return false
@@ -940,9 +941,16 @@ actor AccessibilityController {
         depth: Int,
         maxDepth: Int,
         visited: inout Set<AXKey>,
+        deadline: Date,
+        nodeCap: Int = 5000,
         visitor: (AXUIElement, Int, String) -> Bool
     ) -> Bool {
         guard depth <= maxDepth else { return false }
+        // Wall-clock + node-count budget. Each AX attribute read is an IPC
+        // round trip; a wide tree (thousands of nodes) would otherwise let
+        // list_elements hang the server until the client gives up. Returning
+        // `true` unwinds the recursion. Matches treeWalk/findElements' budget.
+        guard Date() < deadline, visited.count < nodeCap else { return true }
 
         guard visited.insert(AXKey(element: element)).inserted else { return false }
 
@@ -952,7 +960,7 @@ actor AccessibilityController {
         }
 
         for child in childElements(of: element) {
-            if walk(element: child, depth: depth + 1, maxDepth: maxDepth, visited: &visited, visitor: visitor) {
+            if walk(element: child, depth: depth + 1, maxDepth: maxDepth, visited: &visited, deadline: deadline, nodeCap: nodeCap, visitor: visitor) {
                 return true
             }
         }

--- a/Sources/MacControlMCP/AgentMemoryController.swift
+++ b/Sources/MacControlMCP/AgentMemoryController.swift
@@ -31,7 +31,9 @@ actor AgentMemoryController {
         let entries: [Entry]
     }
 
-    private let storePath: URL
+    private var storePath: URL {
+        StoreLocation.baseDirectory.appendingPathComponent("memory.jsonl")
+    }
     private let sessionID: String
     private let isoFormatter: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
@@ -46,10 +48,6 @@ actor AgentMemoryController {
     private var loaded = false
 
     init() {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        self.storePath = home
-            .appendingPathComponent(".mac-control-mcp", isDirectory: true)
-            .appendingPathComponent("memory.jsonl")
         self.sessionID = String(UUID().uuidString.prefix(8)).lowercased()
     }
 

--- a/Sources/MacControlMCP/ArtifactStore.swift
+++ b/Sources/MacControlMCP/ArtifactStore.swift
@@ -25,14 +25,12 @@ actor ArtifactStore {
         let schema: String            // e.g. "mac-control-mcp.image.v1"
     }
 
-    private let dir: URL
+    private var dir: URL {
+        StoreLocation.baseDirectory.appendingPathComponent("artifacts", isDirectory: true)
+    }
     private let ttl: TimeInterval
 
     init(ttl: TimeInterval = 3600) {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        self.dir = home
-            .appendingPathComponent(".mac-control-mcp", isDirectory: true)
-            .appendingPathComponent("artifacts", isDirectory: true)
         self.ttl = ttl
     }
 

--- a/Sources/MacControlMCP/AuditLogController.swift
+++ b/Sources/MacControlMCP/AuditLogController.swift
@@ -20,7 +20,9 @@ actor AuditLogController {
         let metadata: [String: JSONValue]?
     }
 
-    private let logPath: URL
+    private var logPath: URL {
+        StoreLocation.baseDirectory.appendingPathComponent("audit.jsonl")
+    }
     private let sessionID: String
     private let isoFormatter: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
@@ -29,10 +31,6 @@ actor AuditLogController {
     }()
 
     init() {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        self.logPath = home
-            .appendingPathComponent(".mac-control-mcp", isDirectory: true)
-            .appendingPathComponent("audit.jsonl")
         // A short session id so entries from this boot are groupable
         // without recording the full UUID.
         self.sessionID = String(UUID().uuidString.prefix(8)).lowercased()

--- a/Sources/MacControlMCP/MCPProtocol.swift
+++ b/Sources/MacControlMCP/MCPProtocol.swift
@@ -89,8 +89,12 @@ enum JSONValue: Codable, Equatable, Sendable {
     var intValue: Int? {
         switch self {
         case .number(let value):
+            // `Int(exactly:)` rejects non-integral values AND magnitudes
+            // outside Int's range. The old `Int(value)` trapped (SIGTRAP,
+            // whole-process abort) on any large client-supplied number such
+            // as 1e20 or 1e300, which pass the integrality check.
             guard value.rounded() == value else { return nil }
-            return Int(value)
+            return Int(exactly: value)
         case .string(let value):
             return Int(value)
         default:
@@ -177,6 +181,8 @@ struct MCPToolDefinition: Codable, Sendable {
 enum StdioMessageFramer {
     private static let crlfHeaderTerminator = Data("\r\n\r\n".utf8)
     private static let lfHeaderTerminator = Data("\n\n".utf8)
+    /// Upper bound on an accepted Content-Length header (256 MB).
+    static let maxContentLength = 256 * 1024 * 1024
 
     struct HeaderParseError: Error, CustomStringConvertible {
         let description: String
@@ -241,7 +247,14 @@ enum StdioMessageFramer {
             return .malformed(error.description)
         case .success(let contentLength):
             let bodyStart = headerBoundary.bodyStart
-            let bodyEnd = bodyStart + contentLength
+            // Overflow-safe: a near-Int.max Content-Length made `bodyStart +
+            // contentLength` trap (arithmetic overflow, whole-process abort)
+            // before the buffer bounds check could reject it.
+            let (bodyEnd, overflowed) = bodyStart.addingReportingOverflow(contentLength)
+            if overflowed {
+                buffer.removeSubrange(buffer.startIndex..<bodyStart)
+                return .malformed("Content-Length overflows the addressable buffer range.")
+            }
             guard buffer.count >= bodyEnd else { return .needMoreData }
 
             let body = buffer.subdata(in: bodyStart..<bodyEnd)
@@ -311,6 +324,12 @@ enum StdioMessageFramer {
             let value = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
             guard let length = Int(value), length >= 0 else {
                 return .failure(HeaderParseError(description: "Invalid Content-Length header value: '\(value)'."))
+            }
+            // Reject absurd sizes up front so a huge header can't make the
+            // framer buffer unboundedly (memory DoS) while waiting for bytes
+            // that will never arrive. 256 MB is far above any real MCP frame.
+            guard length <= maxContentLength else {
+                return .failure(HeaderParseError(description: "Content-Length \(length) exceeds the \(maxContentLength)-byte limit."))
             }
 
             guard contentLength == nil else {

--- a/Sources/MacControlMCP/MouseController.swift
+++ b/Sources/MacControlMCP/MouseController.swift
@@ -137,8 +137,8 @@ actor MouseController {
                 scrollWheelEvent2Source: source,
                 units: .pixel,
                 wheelCount: 2,
-                wheel1: Int32(deltaY),
-                wheel2: Int32(deltaX),
+                wheel1: Int32(clamping: deltaY),
+                wheel2: Int32(clamping: deltaX),
                 wheel3: 0
               )
         else { return false }

--- a/Sources/MacControlMCP/OsascriptRunner.swift
+++ b/Sources/MacControlMCP/OsascriptRunner.swift
@@ -13,25 +13,21 @@ enum OsascriptRunner {
         var ok: Bool { exitCode == 0 }
     }
 
-    static func run(_ script: String) -> Result {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
-        process.arguments = ["-e", script]
-
-        let outPipe = Pipe()
-        let errPipe = Pipe()
-        process.standardOutput = outPipe
-        process.standardError = errPipe
-
-        do {
-            try process.run()
-            process.waitUntilExit()
-        } catch {
-            return Result(stdout: "", stderr: "Failed to launch osascript: \(error)", exitCode: -1)
-        }
-
-        let out = String(data: outPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        let err = String(data: errPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        return Result(stdout: out, stderr: err, exitCode: process.terminationStatus)
+    /// Run an AppleScript via `osascript -e`. Delegates to `Subprocess`,
+    /// which drains stdout/stderr concurrently (so a script producing a large
+    /// result — e.g. a full DOM/AX dump — cannot deadlock on a full pipe
+    /// buffer) and enforces `timeout` so a hung script cannot wedge the tool
+    /// call, and with it the calling actor, forever. On timeout the runner
+    /// returns a non-zero exit with an explanatory stderr.
+    static func run(_ script: String, timeout: TimeInterval = 30) -> Result {
+        let r = Subprocess.run(
+            executable: "/usr/bin/osascript",
+            arguments: ["-e", script],
+            timeout: timeout
+        )
+        let stderr = r.timedOut
+            ? "osascript exceeded the \(Int(timeout))s timeout and was terminated."
+            : r.stderr
+        return Result(stdout: r.stdout, stderr: stderr, exitCode: r.exitCode)
     }
 }

--- a/Sources/MacControlMCP/PermissionTiers.swift
+++ b/Sources/MacControlMCP/PermissionTiers.swift
@@ -102,7 +102,12 @@ public actor PermissionStore {
     public static let shared = PermissionStore()
 
     private var grants: [String: PermissionGrant] = [:]
-    private let storePath: URL
+    /// `~/.mac-control-mcp/permissions.json` — user-scoped, never shared.
+    /// Computed at access time via `StoreLocation` so test runs redirect
+    /// to a temp dir instead of clobbering the real store.
+    private var storePath: URL {
+        StoreLocation.baseDirectory.appendingPathComponent("permissions.json")
+    }
     private var loaded = false
 
     /// Default TTL when a caller doesn't specify one. 24h balances
@@ -117,13 +122,7 @@ public actor PermissionStore {
         return 24 * 60 * 60
     }()
 
-    private init() {
-        // ~/.mac-control-mcp/permissions.json — user-scoped, never shared.
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        self.storePath = home
-            .appendingPathComponent(".mac-control-mcp", isDirectory: true)
-            .appendingPathComponent("permissions.json")
-    }
+    private init() {}
 
     // MARK: - Lifecycle
 

--- a/Sources/MacControlMCP/ProcessRunner.swift
+++ b/Sources/MacControlMCP/ProcessRunner.swift
@@ -18,43 +18,14 @@ enum ProcessRunner {
     /// `Result.exitCode == -1` means the binary wasn't found / couldn't launch.
     /// Callers switch on `ok` and report `stderr` as the human-readable reason.
     static func run(_ path: String, _ args: [String], timeout: TimeInterval = 10.0) -> Result {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: path)
-        process.arguments = args
-
-        let outPipe = Pipe()
-        let errPipe = Pipe()
-        process.standardOutput = outPipe
-        process.standardError = errPipe
-
-        do {
-            try process.run()
-        } catch {
-            return Result(stdout: "", stderr: "Failed to launch \(path): \(error)", exitCode: -1)
-        }
-
-        // `waitUntilExit` has no timeout variant, so we attach a watchdog that
-        // terminates runaway children. 10s default is generous for CLI tools
-        // but short enough that a hanging `pmset` can't wedge a tool call.
-        let deadline = Date().addingTimeInterval(timeout)
-        let checkQueue = DispatchQueue.global(qos: .utility)
-        let watchdog = DispatchWorkItem {
-            while process.isRunning {
-                if Date() >= deadline {
-                    process.terminate()
-                    return
-                }
-                Thread.sleep(forTimeInterval: 0.05)
-            }
-        }
-        checkQueue.async(execute: watchdog)
-
-        process.waitUntilExit()
-        watchdog.cancel()
-
-        let out = String(data: outPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        let err = String(data: errPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        return Result(stdout: out, stderr: err, exitCode: process.terminationStatus)
+        // Delegates to `Subprocess`, which drains stdout/stderr concurrently
+        // (the previous watchdog killed a child that filled the pipe buffer,
+        // but the reads still happened only after exit, truncating legitimate
+        // large output) and enforces `timeout` with a SIGTERM→SIGKILL
+        // escalation. 10s default is generous for CLI tools but short enough
+        // that a hanging `pmset` can't wedge a tool call.
+        let r = Subprocess.run(executable: path, arguments: args, timeout: timeout)
+        return Result(stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode)
     }
 
     /// Check whether an absolute path exists and is executable. Used by

--- a/Sources/MacControlMCP/StoreLocation.swift
+++ b/Sources/MacControlMCP/StoreLocation.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Resolves the base directory for all persisted mac-control-mcp state
+/// (permission grants, audit log, agent memory, cached artifacts).
+///
+/// - Production: `~/.mac-control-mcp`.
+/// - Overridable via the `MAC_CONTROL_MCP_HOME` environment variable
+///   (absolute path) for operators who relocate the store.
+/// - Under a test run the base is redirected to a per-process temp
+///   directory automatically, so `swift test` can never read or clobber
+///   the real user-level store. Detection keys off XCTest, which is linked
+///   into the SwiftPM test bundle (it also hosts swift-testing suites on
+///   macOS) but is never linked into the shipping server executable.
+///
+/// All four stores read `baseDirectory` at access time rather than caching
+/// it in `init`, so a redirect takes effect even for the `PermissionStore`
+/// singleton regardless of when it was first created.
+enum StoreLocation {
+    static var baseDirectory: URL {
+        let env = ProcessInfo.processInfo.environment
+        if let override = env["MAC_CONTROL_MCP_HOME"], !override.isEmpty {
+            return URL(fileURLWithPath: override, isDirectory: true)
+        }
+        if isRunningUnderTests {
+            return testBaseDirectory
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".mac-control-mcp", isDirectory: true)
+    }
+
+    /// True when executing inside a test host. We detect the runner
+    /// *positively* (never "is this NOT the server binary") — a false
+    /// positive in production would silently redirect real data to a temp
+    /// dir, which is worse than the bug being fixed. Signals, in order:
+    ///   - swift-testing under SwiftPM runs from `swiftpm-testing-helper`
+    ///     (measured: no XCTest linkage, no XCTest env markers);
+    ///   - XCTest-hosted runs use the `xctest` tool / a `*.xctest` bundle
+    ///     and set `XCTestConfigurationFilePath`;
+    ///   - `MAC_CONTROL_MCP_FORCE_TEST_STORE=1` is a manual escape hatch
+    ///     for any runner these heuristics miss.
+    /// None of these match the shipped `mac-control-mcp` executable (run
+    /// directly or from inside the notarized .app), nor `swift run`.
+    static var isRunningUnderTests: Bool {
+        let env = ProcessInfo.processInfo.environment
+        if env["MAC_CONTROL_MCP_FORCE_TEST_STORE"] == "1" { return true }
+        if env["XCTestConfigurationFilePath"] != nil { return true }
+        if env["XCTestSessionIdentifier"] != nil { return true }
+        if NSClassFromString("XCTestCase") != nil { return true }
+        let procName = ProcessInfo.processInfo.processName
+        if procName == "xctest" || procName == "swiftpm-testing-helper" { return true }
+        let exePath = CommandLine.arguments.first ?? ""
+        if exePath.contains(".xctest") || exePath.contains("swiftpm-testing-helper") { return true }
+        return false
+    }
+
+    private static let testBaseDirectory: URL =
+        URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("mac-control-mcp-tests-\(getpid())", isDirectory: true)
+}

--- a/Sources/MacControlMCP/Subprocess.swift
+++ b/Sources/MacControlMCP/Subprocess.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// Shared, deadlock-safe subprocess runner used by `OsascriptRunner` and
+/// `ProcessRunner`.
+///
+/// Two properties the naive `try run(); waitUntilExit(); readToEnd()` pattern
+/// lacked and this guarantees:
+///
+///  1. **Concurrent drain.** stdout and stderr are read on background queues
+///     *while* the child runs. The old code read only after `waitUntilExit`,
+///     so a child writing more than the ~64 KB pipe buffer blocked on write
+///     forever (its reader never ran) — an unkillable hang for `osascript`,
+///     which had no timeout at all.
+///  2. **Bounded wait.** A child that never exits is escalated SIGTERM →
+///     (2 s grace) → SIGKILL, so one wedged subprocess can't pin a tool call
+///     — and, because these run synchronously inside actors, the actor —
+///     indefinitely.
+enum Subprocess {
+    struct Result: Sendable {
+        let stdout: String
+        let stderr: String
+        let exitCode: Int32
+        let timedOut: Bool
+        /// True only on a clean zero exit that did not time out.
+        var ok: Bool { exitCode == 0 && !timedOut }
+    }
+
+    static func run(
+        executable: String,
+        arguments: [String],
+        timeout: TimeInterval
+    ) -> Result {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+
+        // Drain both pipes concurrently so the child never blocks on a full
+        // pipe buffer. Results are guarded by `lock` because the two reads
+        // and the caller touch the buffers from different threads.
+        let lock = NSLock()
+        var outData = Data()
+        var errData = Data()
+        let ioGroup = DispatchGroup()
+        let ioQueue = DispatchQueue(label: "mac-control-mcp.subprocess.io", attributes: .concurrent)
+
+        func drain(_ handle: FileHandle, into store: @escaping (Data) -> Void) {
+            ioGroup.enter()
+            ioQueue.async {
+                let data = handle.readDataToEndOfFile()
+                lock.lock(); store(data); lock.unlock()
+                ioGroup.leave()
+            }
+        }
+        drain(outPipe.fileHandleForReading) { outData = $0 }
+        drain(errPipe.fileHandleForReading) { errData = $0 }
+
+        // Signal on exit rather than polling; lets us wait with a deadline.
+        let done = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in done.signal() }
+
+        do {
+            try process.run()
+        } catch {
+            // Nothing was written to the pipes; cancel the drains.
+            outPipe.fileHandleForReading.closeFile()
+            errPipe.fileHandleForReading.closeFile()
+            return Result(
+                stdout: "",
+                stderr: "Failed to launch \(executable): \(error)",
+                exitCode: -1,
+                timedOut: false
+            )
+        }
+
+        var timedOut = false
+        if done.wait(timeout: .now() + timeout) == .timedOut {
+            timedOut = true
+            process.terminate() // SIGTERM
+            if done.wait(timeout: .now() + 2) == .timedOut {
+                kill(process.processIdentifier, SIGKILL)
+                done.wait() // reap
+            }
+        }
+
+        // Both pipe writers are closed now (process exited), so the drains
+        // hit EOF and finish; wait for the captured bytes.
+        ioGroup.wait()
+
+        lock.lock()
+        let out = outData
+        let err = errData
+        lock.unlock()
+
+        return Result(
+            stdout: String(data: out, encoding: .utf8) ?? "",
+            stderr: String(data: err, encoding: .utf8) ?? "",
+            exitCode: process.terminationStatus,
+            timedOut: timedOut
+        )
+    }
+}

--- a/Sources/MacControlMCP/Tools+V2Phase3.swift
+++ b/Sources/MacControlMCP/Tools+V2Phase3.swift
@@ -292,7 +292,10 @@ extension ToolRegistry {
         let role = arguments["role"]?.stringValue
         let title = arguments["title"]?.stringValue
         let timeout = min(max(arguments["timeout_seconds"]?.doubleValue ?? 5.0, 0.1), 60.0)
-        let intervalMs = max(arguments["poll_interval_ms"]?.intValue ?? 200, 50)
+        // Clamp to [50, 60000] ms: the lower bound avoids a busy-loop, the
+        // upper bound both prevents a UInt64 overflow trap in the nanosecond
+        // multiply below and stops one interval from exceeding the timeout.
+        let intervalMs = min(max(arguments["poll_interval_ms"]?.intValue ?? 200, 50), 60_000)
         let expectDisappear: Bool = {
             if case .bool(let b) = arguments["expect_disappear"] ?? .null { return b }
             return false

--- a/Sources/MacControlMCP/Tools+V2Phase5.swift
+++ b/Sources/MacControlMCP/Tools+V2Phase5.swift
@@ -541,7 +541,7 @@ extension ToolRegistry {
         }
         let titleFilter = arguments["title_contains"]?.stringValue?.lowercased()
         let timeout = min(max(arguments["timeout_seconds"]?.doubleValue ?? 5.0, 0.1), 60.0)
-        let intervalMs = max(arguments["poll_interval_ms"]?.intValue ?? 250, 50)
+        let intervalMs = min(max(arguments["poll_interval_ms"]?.intValue ?? 250, 50), 60_000)
         let deadline = Date().addingTimeInterval(timeout)
 
         while Date() < deadline {
@@ -581,7 +581,7 @@ extension ToolRegistry {
             return invalidArgument("wait_for_app requires bundle_id or name.")
         }
         let timeout = min(max(arguments["timeout_seconds"]?.doubleValue ?? 5.0, 0.1), 60.0)
-        let intervalMs = max(arguments["poll_interval_ms"]?.intValue ?? 250, 50)
+        let intervalMs = min(max(arguments["poll_interval_ms"]?.intValue ?? 250, 50), 60_000)
         let deadline = Date().addingTimeInterval(timeout)
 
         while Date() < deadline {
@@ -631,7 +631,7 @@ extension ToolRegistry {
 
     func callWaitForFileDialog(_ arguments: [String: JSONValue]) async -> ToolCallResult {
         let timeout = min(max(arguments["timeout_seconds"]?.doubleValue ?? 5.0, 0.1), 60.0)
-        let intervalMs = max(arguments["poll_interval_ms"]?.intValue ?? 250, 50)
+        let intervalMs = min(max(arguments["poll_interval_ms"]?.intValue ?? 250, 50), 60_000)
         let deadline = Date().addingTimeInterval(timeout)
 
         while Date() < deadline {

--- a/Sources/MacControlMCP/Tools+V2Phase7.swift
+++ b/Sources/MacControlMCP/Tools+V2Phase7.swift
@@ -584,7 +584,7 @@ extension ToolRegistry {
         }
         let ok = await mouse.click(at: CGPoint(x: x, y: y), button: .right)
         return ok
-            ? successResult("right click at (\(Int(x)),\(Int(y)))",
+            ? successResult(String(format: "right click at (%.0f,%.0f)", x, y),
                             ["ok": .bool(true), "x": .number(x), "y": .number(y)])
             : errorResult("right_click failed", ["ok": .bool(false)])
     }
@@ -602,7 +602,7 @@ extension ToolRegistry {
         }
         let ok = await mouse.doubleClick(at: CGPoint(x: x, y: y), button: button)
         return ok
-            ? successResult("double-click at (\(Int(x)),\(Int(y)))",
+            ? successResult(String(format: "double-click at (%.0f,%.0f)", x, y),
                             ["ok": .bool(true), "x": .number(x), "y": .number(y), "button": .string(btnRaw)])
             : errorResult("double_click failed", ["ok": .bool(false)])
     }

--- a/Sources/MacControlMCP/Tools+V2Phase9.swift
+++ b/Sources/MacControlMCP/Tools+V2Phase9.swift
@@ -388,8 +388,13 @@ extension ToolRegistry {
                   case .number(let x) = obj["x"] ?? .null,
                   case .number(let y) = obj["y"] ?? .null,
                   case .number(let w) = obj["width"] ?? .null,
-                  case .number(let h) = obj["height"] ?? .null else { continue }
-            regions.append(.init(x: Int(x), y: Int(y), width: Int(w), height: Int(h)))
+                  case .number(let h) = obj["height"] ?? .null,
+                  // Reject out-of-Int-range coordinates (Int(Double) traps on
+                  // e.g. 1e300); skip the malformed region rather than crash.
+                  let ix = Int(exactly: x.rounded()), let iy = Int(exactly: y.rounded()),
+                  let iw = Int(exactly: w.rounded()), let ih = Int(exactly: h.rounded())
+            else { continue }
+            regions.append(.init(x: ix, y: iy, width: iw, height: ih))
         }
         guard !regions.isEmpty else {
             return invalidArgument("regions array had no valid entries (need x/y/width/height)")

--- a/Sources/MacControlMCP/Tools.swift
+++ b/Sources/MacControlMCP/Tools.swift
@@ -646,10 +646,10 @@ final class ToolRegistry: @unchecked Sendable {
         // `auto` (default) now tries clipboard → keys → ax for event
         // fidelity on React/Angular SPAs. See TypeStrategy docs in
         // AccessibilityController.swift.
-        let strategyArg = arguments["strategy"]?.stringValue?.lowercased() ?? "auto"
-        guard let strategy = AccessibilityController.TypeStrategy(rawValue: strategyArg) else {
+        let strategyArg = arguments["strategy"]?.stringValue
+        guard let strategy = AccessibilityController.TypeStrategy.resolve(argument: strategyArg) else {
             return invalidArgument(
-                "type_text strategy must be one of: auto, clipboard, keys, ax (got '\(strategyArg)')."
+                "type_text strategy must be one of: auto, clipboard, keys, ax (got '\(strategyArg ?? "")')."
             )
         }
 

--- a/Sources/MacControlMCP/VoiceController.swift
+++ b/Sources/MacControlMCP/VoiceController.swift
@@ -88,28 +88,53 @@ actor VoiceController {
         let request = SFSpeechURLRecognitionRequest(url: url)
         request.requiresOnDeviceRecognition = recognizer.supportsOnDeviceRecognition
 
+        // Hold strong refs to the recognizer + task and enforce a timeout.
+        // The old code resumed only on error or `isFinal`, so a recognition
+        // that stalls (e.g. server-side path when on-device isn't supported,
+        // with no/slow network) left the continuation — and the tool call —
+        // hanging forever. The lock-guarded box makes single-resume and the
+        // cross-thread ref lifetime safe.
+        let timeout: TimeInterval = 30
         return await withCheckedContinuation { continuation in
-            var resumed = false
-            recognizer.recognitionTask(with: request) { result, error in
-                if resumed { return }
+            final class State: @unchecked Sendable {
+                let lock = NSLock()
+                var resumed = false
+                var task: SFSpeechRecognitionTask?
+                var recognizer: SFSpeechRecognizer?
+            }
+            let state = State()
+            state.recognizer = recognizer
+
+            let finish: @Sendable (SpeechResult) -> Void = { result in
+                state.lock.lock()
+                if state.resumed { state.lock.unlock(); return }
+                state.resumed = true
+                let task = state.task
+                state.task = nil
+                state.recognizer = nil   // release the strong ref
+                state.lock.unlock()
+                task?.cancel()
+                continuation.resume(returning: result)
+            }
+
+            let task = recognizer.recognitionTask(with: request) { result, error in
                 if let error {
-                    resumed = true
-                    continuation.resume(returning: SpeechResult(
-                        ok: false, text: nil, language: language,
-                        error: "recognition failed: \(error.localizedDescription)"
-                    ))
+                    finish(SpeechResult(ok: false, text: nil, language: language,
+                                        error: "recognition failed: \(error.localizedDescription)"))
                     return
                 }
                 guard let result else { return }
                 if result.isFinal {
-                    resumed = true
-                    continuation.resume(returning: SpeechResult(
-                        ok: true,
-                        text: result.bestTranscription.formattedString,
-                        language: language,
-                        error: nil
-                    ))
+                    finish(SpeechResult(ok: true,
+                                        text: result.bestTranscription.formattedString,
+                                        language: language, error: nil))
                 }
+            }
+            state.lock.lock(); state.task = task; state.lock.unlock()
+
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
+                finish(SpeechResult(ok: false, text: nil, language: language,
+                                    error: "speech recognition timed out after \(Int(timeout))s"))
             }
         }
         #else

--- a/Tests/MacControlMCPTests/BugFixesV0_2_6Tests.swift
+++ b/Tests/MacControlMCPTests/BugFixesV0_2_6Tests.swift
@@ -16,12 +16,17 @@ struct BugFixesV0_2_6Tests {
 
     // MARK: - Bug #4 — title fallback is empty-string aware
 
-    @Test("Bug #4 — TypeStrategy.auto stays the default")
+    @Test("Bug #4 — an omitted strategy argument resolves to auto")
     func bug4TypeStrategyAuto() {
-        // If somebody accidentally changes the default away from auto we
-        // break the React/Angular SPA reliability fix. Lock it in.
-        let r = AccessibilityController.TypeStrategy(rawValue: "auto")
-        #expect(r == .auto)
+        // The regression this guards: `type_text` with no `strategy` arg must
+        // fall back to auto (clipboard → keys → ax). Assert the real
+        // resolution path, not just that the enum has an `auto` case, so a
+        // drift in the default is actually caught.
+        #expect(AccessibilityController.TypeStrategy.default == .auto)
+        #expect(AccessibilityController.TypeStrategy.resolve(argument: nil) == .auto)
+        #expect(AccessibilityController.TypeStrategy.resolve(argument: "") == .auto)
+        #expect(AccessibilityController.TypeStrategy.resolve(argument: "AX") == .ax)
+        #expect(AccessibilityController.TypeStrategy.resolve(argument: "bogus") == nil)
     }
 
     // MARK: - Bug #3 — AXPress silent success on disabled targets
@@ -101,12 +106,13 @@ struct BugFixesV0_2_6Tests {
 
     // MARK: - Bug #10 — triple_click
 
-    @Test("Bug #10 — MouseController exposes tripleClick + multiClick")
+    @Test("Bug #10 — MouseController exposes tripleClick + multiClick",
+          .enabled(if: TestSupport.hidTestingEnabled))
     func bug10MouseTripleClickSurface() async {
+        // The mere existence of these methods is a compile-time guarantee;
+        // the calls below post real HID clicks at (0,0), which is on-screen
+        // (top-left), so only run them when HID testing is opted in.
         let mouse = MouseController()
-        // We can't actually post events during test (no HID tap in CI),
-        // but posting to an off-screen coord won't hurt — the method
-        // should return cleanly.
         _ = await mouse.doubleClick(at: .zero)
         _ = await mouse.tripleClick(at: .zero)
         _ = await mouse.multiClick(at: .zero, count: 1)

--- a/Tests/MacControlMCPTests/CrashRegressionTests.swift
+++ b/Tests/MacControlMCPTests/CrashRegressionTests.swift
@@ -1,0 +1,107 @@
+import Testing
+import Foundation
+@testable import MacControlMCP
+
+/// Regression guards for the v0.8.x crash sweep. Each test drives an input
+/// that used to abort the whole server process (SIGTRAP / arithmetic
+/// overflow, exit 133) and asserts it is now rejected gracefully. Because a
+/// Swift trap kills the test runner too, a regression here shows up as a
+/// hard crash of the suite — exactly the signal we want.
+@Suite("Crash regressions — untrusted numeric input")
+struct CrashRegressionTests {
+
+    // MARK: - JSONValue.intValue out-of-range (MCPProtocol.swift)
+
+    private func decode(_ json: String) -> JSONValue {
+        try! JSONDecoder().decode(JSONValue.self, from: Data(json.utf8))
+    }
+
+    @Test("intValue returns nil for out-of-Int-range JSON numbers instead of trapping")
+    func intValueOutOfRange() {
+        // Each of these parses as a large integral Double and used to trap
+        // in Int(value). They must now yield nil.
+        #expect(decode("99999999999999999999").intValue == nil)   // ~1e20
+        #expect(decode("1e300").intValue == nil)
+        #expect(decode("-1e300").intValue == nil)
+        #expect(decode("1e19").intValue == nil)                    // > Int.max (9.22e18)
+    }
+
+    @Test("intValue still accepts in-range integers and rejects fractions")
+    func intValueInRange() {
+        #expect(decode("0").intValue == 0)
+        #expect(decode("123").intValue == 123)
+        #expect(decode("-4096").intValue == -4096)
+        #expect(decode("9007199254740992").intValue == 9007199254740992) // 2^53, exact in Double
+        #expect(decode("1.5").intValue == nil)
+        #expect(decode("\"42\"").intValue == 42)                   // string form still parses
+    }
+
+    // MARK: - Content-Length framing overflow (MCPProtocol.swift)
+
+    private func pop(_ raw: String) -> StdioMessageFramer.ParseResult {
+        var buffer = Data(raw.utf8)
+        return StdioMessageFramer.popMessage(from: &buffer)
+    }
+
+    @Test("a near-Int.max Content-Length is rejected, not overflow-trapped")
+    func contentLengthOverflow() {
+        // bodyStart + Int.max used to overflow-trap before the bounds guard.
+        if case .malformed = pop("Content-Length: 9223372036854775807\r\n\r\n{}") {
+            // expected
+        } else {
+            Issue.record("expected .malformed for Int.max Content-Length")
+        }
+    }
+
+    @Test("an oversized-but-valid Content-Length is rejected by the cap")
+    func contentLengthCap() {
+        let tooBig = StdioMessageFramer.maxContentLength + 1
+        if case .malformed = pop("Content-Length: \(tooBig)\r\n\r\n{}") {
+            // expected
+        } else {
+            Issue.record("expected .malformed for Content-Length past the cap")
+        }
+    }
+
+    @Test("a normal Content-Length frame still parses")
+    func contentLengthHappyPath() {
+        let body = "{\"jsonrpc\":\"2.0\"}"
+        if case .message(let data) = pop("Content-Length: \(body.utf8.count)\r\n\r\n\(body)") {
+            #expect(String(data: data, encoding: .utf8) == body)
+        } else {
+            Issue.record("expected .message for a well-formed frame")
+        }
+    }
+
+    // MARK: - scroll delta narrowing to Int32 (MouseController.swift)
+
+    @Test("scroll with out-of-Int32-range deltas does not trap")
+    func scrollHugeDelta() async {
+        // Int32(deltaY) used to trap on > 2.1e9. Int32(clamping:) saturates.
+        // Success depends on a HID tap being available, so we only assert it
+        // returns (Bool) without crashing the process.
+        let mouse = MouseController()
+        _ = await mouse.scroll(deltaX: 3_000_000_000, deltaY: 3_000_000_000, at: nil)
+        _ = await mouse.scroll(deltaX: Int.min, deltaY: Int.max, at: nil)
+    }
+
+    // MARK: - redact_image_regions coordinate narrowing (Tools+V2Phase9.swift)
+
+    @Test("redact_image_regions rejects out-of-range coords instead of trapping")
+    func redactHugeCoords() async {
+        let registry = ToolRegistry(accessibility: AccessibilityController())
+        let result = await registry.callTool(
+            name: "redact_image_regions",
+            arguments: [
+                "path": .string("/nonexistent/path.png"),
+                "regions": .array([
+                    .object(["x": .number(1e300), "y": .number(1e300),
+                             "width": .number(1e300), "height": .number(1e300)])
+                ])
+            ]
+        )
+        // The out-of-range region is skipped, so we reach the "no valid
+        // regions" argument error — not a crash.
+        #expect(result.isError == true)
+    }
+}

--- a/Tests/MacControlMCPTests/Phase4ToolsTests.swift
+++ b/Tests/MacControlMCPTests/Phase4ToolsTests.swift
@@ -65,10 +65,14 @@ struct Phase4ToolsTests {
         let r2 = await registry.callTool(name: "file_dialog_select_item", arguments: [:])
         #expect(r2.isError == true)
 
-        // confirm has no required args — returns ok regardless of whether a
-        // dialog is actually present (the keystroke is posted either way).
-        let r3 = await registry.callTool(name: "file_dialog_confirm", arguments: [:])
-        #expect(r3.isError == false)
+        // confirm has no required args and posts a real Return keystroke into
+        // whatever app is frontmost — only exercise it when HID testing is
+        // explicitly enabled, so a plain `swift test` can't fire a synthetic
+        // keypress into the developer's session.
+        if TestSupport.hidTestingEnabled {
+            let r3 = await registry.callTool(name: "file_dialog_confirm", arguments: [:])
+            #expect(r3.isError == false)
+        }
     }
 
     @Test("WindowController.setState recognizes canonical state names")

--- a/Tests/MacControlMCPTests/SubprocessTests.swift
+++ b/Tests/MacControlMCPTests/SubprocessTests.swift
@@ -1,0 +1,43 @@
+import Testing
+import Foundation
+@testable import MacControlMCP
+
+@Suite("Subprocess — deadlock + timeout safety")
+struct SubprocessTests {
+
+    @Test("captures output larger than the pipe buffer without deadlocking")
+    func largeOutputNoDeadlock() throws {
+        // ~512 KB, far past the ~64 KB pipe buffer that used to wedge the
+        // read-after-wait pattern. If the drain regressed this would hang
+        // (and the test would time out) rather than fail cleanly.
+        let bytes = 512 * 1024
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("mcp-subproc-\(UUID().uuidString).txt")
+        try Data(repeating: UInt8(ascii: "x"), count: bytes).write(to: tmp)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let r = Subprocess.run(executable: "/bin/cat", arguments: [tmp.path], timeout: 10)
+        #expect(r.ok)
+        #expect(r.timedOut == false)
+        #expect(r.stdout.utf8.count == bytes)
+    }
+
+    @Test("terminates a hung child at the timeout instead of blocking forever")
+    func hungChildIsKilled() {
+        let start = Date()
+        // `sleep 30` writes nothing and never exits within the window.
+        let r = Subprocess.run(executable: "/bin/sleep", arguments: ["30"], timeout: 1)
+        let elapsed = Date().timeIntervalSince(start)
+        #expect(r.timedOut)
+        #expect(r.ok == false)
+        // Should return shortly after the 1s deadline, well under sleep's 30s.
+        #expect(elapsed < 8)
+    }
+
+    @Test("a normal command returns stdout and a clean exit")
+    func happyPath() {
+        let r = Subprocess.run(executable: "/bin/echo", arguments: ["hello"], timeout: 5)
+        #expect(r.ok)
+        #expect(r.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "hello")
+    }
+}

--- a/Tests/MacControlMCPTests/TestSupport.swift
+++ b/Tests/MacControlMCPTests/TestSupport.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+@testable import MacControlMCP
+
+/// Shared helpers for keeping the test suite from mutating real user state.
+enum TestSupport {
+    /// Real HID posting (mouse clicks, key presses) is disabled by default
+    /// so `swift test` never fires synthetic events into whatever app is
+    /// frontmost on the developer's machine. Set `MAC_CONTROL_MCP_TEST_HID=1`
+    /// to opt in on a dedicated/CI machine.
+    static var hidTestingEnabled: Bool {
+        ProcessInfo.processInfo.environment["MAC_CONTROL_MCP_TEST_HID"] == "1"
+    }
+}
+
+@Suite("Store isolation safety net")
+struct StoreLocationTests {
+    @Test("test runs never resolve to the real ~/.mac-control-mcp store")
+    func redirectsAwayFromRealHome() {
+        let base = StoreLocation.baseDirectory.standardizedFileURL.path
+        let realHome = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".mac-control-mcp", isDirectory: true)
+            .standardizedFileURL.path
+        #expect(StoreLocation.isRunningUnderTests)
+        #expect(base != realHome,
+                "Persisted-store base must be redirected during tests, got \(base)")
+    }
+}

--- a/Tests/MacControlMCPTests/ToolRegistryV2Tests.swift
+++ b/Tests/MacControlMCPTests/ToolRegistryV2Tests.swift
@@ -1,5 +1,6 @@
 import Testing
 import ApplicationServices
+import AppKit
 @testable import MacControlMCP
 
 @Suite("ToolRegistry v0.2.0 tools", .serialized)
@@ -21,6 +22,24 @@ struct ToolRegistryV2Tests {
 
     @Test("clipboard round-trip")
     func clipboardRoundTrip() async {
+        // Preserve the user's real clipboard — this test overwrites it.
+        let pasteboard = NSPasteboard.general
+        let savedItems: [NSPasteboardItem] = (pasteboard.pasteboardItems ?? []).compactMap { item in
+            let copy = NSPasteboardItem()
+            var copiedAny = false
+            for type in item.types {
+                if let data = item.data(forType: type) {
+                    copy.setData(data, forType: type)
+                    copiedAny = true
+                }
+            }
+            return copiedAny ? copy : nil
+        }
+        defer {
+            pasteboard.clearContents()
+            if !savedItems.isEmpty { pasteboard.writeObjects(savedItems) }
+        }
+
         let registry = ToolRegistry(accessibility: AccessibilityController())
         let marker = "mcp-test-\(UUID().uuidString)"
 


### PR DESCRIPTION
## PR-1 of 3 — crashes, hangs, and test-suite data loss

First and most urgent phase of the verified bug-hunt remediation (57 confirmed findings, adversarially verified 3 ways each). This PR covers everything that **crashes the whole server, hangs it, or corrupts real user state** — 15 findings. PR-2 (silent no-ops) and PR-3 (escaping / coordinates / logic) follow.

### Safety net first (Phase 0)
- **`swift test` was overwriting the user's real `~/.mac-control-mcp/permissions.json` and appending junk to their audit/memory logs** on every run — verified live (all three real files mutated by a pre-fix run). New `StoreLocation` redirects all four stores (permissions, audit, memory, artifacts) to a per-process temp dir whenever a test runner is detected (`swiftpm-testing-helper`/`xctest`), or when `MAC_CONTROL_MCP_HOME` is set. Detection is **positive-only** so production can never misfire.
- Clipboard round-trip now saves/restores the real clipboard; real-HID tests (keystroke/mouse) gated behind `MAC_CONTROL_MCP_TEST_HID`; the TypeStrategy-default test now asserts the real resolution path.

### Crashes — every one aborted the whole process (exit 133) from a single request
- `JSONValue.intValue`: `Int(Double)` trapped on any out-of-range client number (`1e20`, `1e300`) → `Int(exactly:)`. Fixes **every int-typed argument** (pid, max_depth, …).
- Content-Length framer: `bodyStart + contentLength` overflow-trapped on a near-`Int.max` header → overflow-safe add + 256 MB cap.
- `scroll`: `Int32(delta)` trapped >2.1e9 → `Int32(clamping:)`.
- `poll_interval_ms`: `UInt64(ms) * 1e6` overflow-trapped → clamp `[50, 60000]` (also stops one interval exceeding the timeout). 4 sites.
- `redact_image_regions` / `right_click` / `double_click`: `Int(Double)` on coords → `Int(exactly:)` / `%.0f`.

### Hangs
- **Subprocess deadlock (root-cause fix, ~40 call sites, 8 controllers):** new `Subprocess` runner drains stdout/stderr concurrently and enforces a timeout (SIGTERM→2s→SIGKILL). `OsascriptRunner` had **no timeout** and read pipes only after `waitUntilExit`, so any script emitting >64 KB (e.g. a DOM/AX dump from `browser_visible_text`) hung the server forever. `ProcessRunner` truncated large output. Both now delegate to `Subprocess`.
- `list_elements` and `ax_snapshot_capture` AX walkers had no wall-clock/node budget → added the shared 5 s / 5000-node cap.
- `speech_to_text` continuation had no timeout → 30 s timeout + strong recognizer/task refs.
- `wait_for_ax_notification`: observer cleanup installed *after* the runloop source was armed → reordered to close the leak/race window.

### Verification
- **176 tests pass** (10 new crash/deadlock regressions, several reproducing the exact exit-133 inputs and the >64 KB deadlock).
- Real store confirmed **untouched** after a full suite run.
- AX walker bounds are exercised by the existing RealAppMatrix/ControlZoo integration suites.

### Manual smoke (paths not fully coverable headlessly)
- `speech_to_text` on a valid audio file; confirm it returns (and times out cleanly with no audio input).
- `wait_for_ax_notification` against a real app that posts the notification.
- A `browser_visible_text` / DOM dump on a large page (previously the deadlock trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
