### PR TITLE
fix: silent no-ops — tools that report success but do nothing (bug-hunt PR-2/3)

### DIFF
--- a/Sources/MacControlMCP/AXSnapshotController.swift
+++ b/Sources/MacControlMCP/AXSnapshotController.swift
@@ -148,7 +148,10 @@ actor AXSnapshotController {
 
         let role = stringAttr(element, kAXRoleAttribute)
         let title = stringAttr(element, kAXTitleAttribute)
-        let value = stringAttr(element, kAXValueAttribute)
+        // Use a value-aware getter: checkboxes/sliders/steppers/radios expose
+        // kAXValue as a number/bool, which `stringAttr` dropped as nil — so
+        // toggling a checkbox produced no diff. Stringify numbers too.
+        let value = valueString(element, kAXValueAttribute)
         let pos = pointAttr(element, kAXPositionAttribute)
         let size = sizeAttr(element, kAXSizeAttribute)
 
@@ -175,6 +178,19 @@ actor AXSnapshotController {
         var raw: CFTypeRef?
         guard AXUIElementCopyAttributeValue(el, attr as CFString, &raw) == .success else { return nil }
         return raw as? String
+    }
+
+    /// Like `stringAttr` but also captures numeric/boolean AX values
+    /// (checkbox 0/1, slider positions, stepper counts) that come back as
+    /// CFNumber/CFBoolean rather than CFString.
+    private func valueString(_ el: AXUIElement, _ attr: String) -> String? {
+        var raw: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(el, attr as CFString, &raw) == .success,
+              let v = raw else { return nil }
+        if let s = v as? String { return s }
+        if let n = v as? NSNumber { return n.stringValue }
+        if CFGetTypeID(v) == AXValueGetTypeID() { return String(describing: v) }
+        return nil
     }
 
     private func pointAttr(_ el: AXUIElement, _ attr: String) -> (x: Double, y: Double)? {

--- a/Sources/MacControlMCP/AppleAppsController.swift
+++ b/Sources/MacControlMCP/AppleAppsController.swift
@@ -2,6 +2,9 @@ import Foundation
 #if canImport(EventKit)
 import EventKit
 #endif
+#if canImport(Contacts)
+import Contacts
+#endif
 
 /// Native Apple-app automation: Messages, Mail, Calendar, Reminders, Contacts.
 ///
@@ -435,72 +438,35 @@ actor AppleAppsController {
         public let emails: [String]
     }
 
-    /// Search Contacts.app by name substring. Returns phone numbers + emails
-    /// — useful for the "find Adel's phone" → "imessage_send" handoff.
+    /// Search contacts by name substring via CNContactStore — works whether or
+    /// not Contacts.app is running (no AppleScript / no -600 error).
     func searchContacts(query: String, limit: Int) -> Result<[Contact]> {
-        func esc(_ s: String) -> String {
-            s.replacingOccurrences(of: "\\", with: "\\\\")
-             .replacingOccurrences(of: "\"", with: "\\\"")
-        }
+        #if canImport(Contacts)
         let cap = max(1, min(limit, 50))
-        let script = """
-        tell application "Contacts"
-            set out to {}
-            set matches to (every person whose name contains "\(esc(query))")
-            set n to (count of matches)
-            if n > \(cap) then set n to \(cap)
-            repeat with i from 1 to n
-                set p to item i of matches
-                set nm to (name of p as string)
-                set phoneList to ""
-                repeat with ph in (phones of p)
-                    set phoneList to phoneList & (value of ph as string) & ";"
-                end repeat
-                set emailList to ""
-                repeat with em in (emails of p)
-                    set emailList to emailList & (value of em as string) & ";"
-                end repeat
-                set end of out to nm & "||" & phoneList & "||" & emailList
-            end repeat
-            return out
-        end tell
-        """
-        let r = OsascriptRunner.run(script)
-        guard r.ok else {
+        let store = CNContactStore()
+        let keys: [CNKeyDescriptor] = [
+            CNContactGivenNameKey as CNKeyDescriptor,
+            CNContactFamilyNameKey as CNKeyDescriptor,
+            CNContactPhoneNumbersKey as CNKeyDescriptor,
+            CNContactEmailAddressesKey as CNKeyDescriptor,
+        ]
+        let predicate = CNContact.predicateForContacts(matchingName: query)
+        do {
+            let raw = try store.unifiedContacts(matching: predicate, keysToFetch: keys)
+            let contacts: [Contact] = raw.prefix(cap).map { c in
+                let name = "\(c.givenName) \(c.familyName)"
+                    .trimmingCharacters(in: .whitespaces)
+                let phones = c.phoneNumbers.map { $0.value.stringValue }
+                let emails = c.emailAddresses.map { String($0.value) }
+                return Contact(name: name, phones: phones, emails: emails)
+            }
+            return Result(ok: true, data: contacts, error: nil)
+        } catch {
             return Result(ok: false, data: nil,
-                          error: r.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
+                          error: "CNContactStore: \(error.localizedDescription)")
         }
-        let lines = r.stdout
-            .components(separatedBy: ", ")
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { !$0.isEmpty }
-        // v0.7.1 fix (BUG 4): AppleScript's `phones of p` values can
-        // contain embedded newlines (mobile numbers formatted by
-        // Contacts.app) and stray left-parens when the phone field is
-        // free-text. Strip whitespace + newlines, drop empties, clean
-        // leading punctuation that isn't a `+` or digit.
-        func cleanPhone(_ raw: String) -> String? {
-            var s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-            // Strip a single leading `(` when it's immediately followed by
-            // a `+` — seen in contacts stored as `(+31 (6) ...`.
-            if s.hasPrefix("(+") { s.removeFirst() }
-            return s.isEmpty ? nil : s
-        }
-        func cleanEmail(_ raw: String) -> String? {
-            let s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !s.isEmpty, s.contains("@") else { return nil }
-            return s
-        }
-        let contacts: [Contact] = lines.compactMap { line in
-            let parts = line.components(separatedBy: "||")
-            guard parts.count >= 3 else { return nil }
-            let name = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
-            let phones = parts[1].split(separator: ";")
-                .compactMap { cleanPhone(String($0)) }
-            let emails = parts[2].split(separator: ";")
-                .compactMap { cleanEmail(String($0)) }
-            return Contact(name: name, phones: phones, emails: emails)
-        }
-        return Result(ok: true, data: contacts, error: nil)
+        #else
+        return Result(ok: false, data: nil, error: "Contacts framework not available on this platform.")
+        #endif
     }
 }

--- a/Sources/MacControlMCP/AppleAppsController.swift
+++ b/Sources/MacControlMCP/AppleAppsController.swift
@@ -388,25 +388,34 @@ actor AppleAppsController {
     func listReminders(includeCompleted: Bool, limit: Int) -> Result<[ReminderSummary]> {
         let cap = max(1, min(limit, 200))
         let filter = includeCompleted ? "" : "whose completed is false"
+        // `total` caps globally — the old `if n > cap` capped per list, so a
+        // `limit` of N returned up to N×(number of lists). Records are joined
+        // with a sentinel and coerced to one string: the old code let osascript
+        // print the list comma-separated and split on ", ", silently dropping
+        // any reminder whose title contained ", ".
         let script = """
         tell application "Reminders"
             set out to {}
+            set total to 0
             set ls to lists
             repeat with l in ls
+                if total ≥ \(cap) then exit repeat
                 try
                     set ln to (name of l as string)
                     set items to (every reminder of l \(filter))
-                    set n to (count of items)
-                    if n > \(cap) then set n to \(cap)
-                    repeat with i from 1 to n
-                        set r to item i of items
+                    repeat with r in items
+                        if total ≥ \(cap) then exit repeat
                         set t to (name of r as string)
                         set c to completed of r
                         set end of out to ln & "||" & t & "||" & (c as string)
+                        set total to total + 1
                     end repeat
                 end try
             end repeat
-            return out
+            set AppleScript's text item delimiters to "§§REC§§"
+            set outStr to out as string
+            set AppleScript's text item delimiters to ""
+            return outStr
         end tell
         """
         let r = OsascriptRunner.run(script)
@@ -415,7 +424,7 @@ actor AppleAppsController {
                           error: r.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
         }
         let lines = r.stdout
-            .components(separatedBy: ", ")
+            .components(separatedBy: "§§REC§§")
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
         let reminders: [ReminderSummary] = lines.compactMap { line in

--- a/Sources/MacControlMCP/AppleNativeController.swift
+++ b/Sources/MacControlMCP/AppleNativeController.swift
@@ -214,10 +214,20 @@ actor AppleNativeController {
     /// return a structured hint instructing the user to create one.
     func invokeAppIntent(bundleId: String, intent: String, input: String?) async -> AppIntentInvokeResult {
         var args = ["run", intent]
+        // `shortcuts run` has no `--input <text>` flag (that made every call
+        // with input fail); it reads input from a file via `--input-path`.
+        // Stage the text in a temp file and clean it up afterwards.
+        var tempInput: URL?
         if let input, !input.isEmpty {
-            args.append(contentsOf: ["--input", input])
+            let url = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("mac-control-mcp-intent-\(UUID().uuidString).txt")
+            if (try? input.write(to: url, atomically: true, encoding: .utf8)) != nil {
+                args.append(contentsOf: ["--input-path", url.path])
+                tempInput = url
+            }
         }
         let r = ProcessRunner.run("/usr/bin/shortcuts", args, timeout: 30)
+        if let tempInput { try? FileManager.default.removeItem(at: tempInput) }
         return AppIntentInvokeResult(
             ok: r.ok,
             bundleId: bundleId,

--- a/Sources/MacControlMCP/AuditLogController.swift
+++ b/Sources/MacControlMCP/AuditLogController.swift
@@ -104,7 +104,9 @@ actor AuditLogController {
             out.append(entry)
             if out.count >= limit { break }
         }
-        return out.reversed() // caller gets chronological order
+        // Newest-first, matching the audit_log_read tool contract. The loop
+        // above already walks lines newest→oldest, so `out` is newest-first.
+        return out
     }
 
     private func ensureParentExists() throws {

--- a/Sources/MacControlMCP/HardwareController.swift
+++ b/Sources/MacControlMCP/HardwareController.swift
@@ -202,8 +202,13 @@ actor HardwareController {
         case "off", "disable":
             arg = "off"
         case "toggle":
+            // `nightlight status` prints "on"/"off"; it never prints "enabled",
+            // so the old check always fell through to "on" (toggle could never
+            // turn Night Shift off). Detect the real off-state instead.
             let cur = ProcessRunner.run(bin, ["status"])
-            arg = cur.stdout.contains("enabled") ? "off" : "on"
+            let status = cur.stdout.lowercased()
+            let currentlyOn = status.contains("on") && !status.contains("off")
+            arg = currentlyOn ? "off" : "on"
         default:
             return ToggleResult(
                 ok: false, target: "night_shift", newState: nil,

--- a/Sources/MacControlMCP/HardwareController.swift
+++ b/Sources/MacControlMCP/HardwareController.swift
@@ -3,6 +3,9 @@ import CoreGraphics
 #if canImport(CoreWLAN)
 import CoreWLAN
 #endif
+#if canImport(AppKit)
+import AppKit
+#endif
 
 /// Hardware-adjacent controls: display brightness, Wi-Fi, Bluetooth,
 /// Night Shift, AirPlay. macOS gates most of these behind system daemons
@@ -149,30 +152,56 @@ actor HardwareController {
             )
         }
         if let direction {
-            let keyCode: CGKeyCode
+            // Brightness is a system-defined ("aux") key, NOT a regular
+            // keyboard virtualKey. The old code posted CGKeyCodes 144/145,
+            // which aren't the brightness keys and changed nothing while
+            // still reporting ok:true. Post NX_KEYTYPE_BRIGHTNESS_UP/DOWN as
+            // NSSystemDefined events, the documented way to drive the keys.
+            #if canImport(AppKit)
+            let auxKey: Int32
             switch direction.lowercased() {
-            case "up":   keyCode = 144  // F1/F2 mapped to brightness on most Macs — use private F-codes
-            case "down": keyCode = 145
+            case "up":   auxKey = 2   // NX_KEYTYPE_BRIGHTNESS_UP
+            case "down": auxKey = 3   // NX_KEYTYPE_BRIGHTNESS_DOWN
             default:
                 return BrightnessResult(
-                    ok: false, level: nil, method: "cgevent",
+                    ok: false, level: nil, method: "nsevent",
                     hint: "direction must be up|down"
                 )
             }
-            guard let src = CGEventSource(stateID: .combinedSessionState) else {
-                return BrightnessResult(
-                    ok: false, level: nil, method: "cgevent",
-                    hint: "CGEventSource() returned nil"
-                )
+            func postAux(_ key: Int32, keyDown: Bool) -> Bool {
+                let state = keyDown ? 0xA : 0xB
+                let data1 = (Int(key) << 16) | (state << 8)
+                guard let ev = NSEvent.otherEvent(
+                    with: .systemDefined,
+                    location: .zero,
+                    modifierFlags: NSEvent.ModifierFlags(rawValue: UInt(state << 8)),
+                    timestamp: ProcessInfo.processInfo.systemUptime,
+                    windowNumber: 0,
+                    context: nil,
+                    subtype: 8,
+                    data1: data1,
+                    data2: -1
+                ), let cg = ev.cgEvent else { return false }
+                cg.post(tap: .cghidEventTap)
+                return true
             }
+            var posted = false
             for _ in 0..<4 {
-                let down = CGEvent(keyboardEventSource: src, virtualKey: keyCode, keyDown: true)
-                let up   = CGEvent(keyboardEventSource: src, virtualKey: keyCode, keyDown: false)
-                down?.post(tap: .cghidEventTap)
-                up?.post(tap: .cghidEventTap)
+                let d = postAux(auxKey, keyDown: true)
+                let u = postAux(auxKey, keyDown: false)
+                posted = posted || (d && u)
                 Thread.sleep(forTimeInterval: 0.05)
             }
-            return BrightnessResult(ok: true, level: nil, method: "cgevent", hint: nil)
+            return posted
+                ? BrightnessResult(ok: true, level: nil, method: "nsevent", hint: nil)
+                : BrightnessResult(ok: false, level: nil, method: "nsevent",
+                                   hint: "failed to construct NSSystemDefined brightness event")
+            #else
+            return BrightnessResult(
+                ok: false, level: nil, method: "none",
+                hint: "brightness direction keys require AppKit (macOS)"
+            )
+            #endif
         }
         return BrightnessResult(
             ok: false, level: nil, method: "none",

--- a/Sources/MacControlMCP/MissionControlController.swift
+++ b/Sources/MacControlMCP/MissionControlController.swift
@@ -163,13 +163,21 @@ actor MissionControlController {
                 error: "CGEventSource() returned nil"
             )
         }
-        _ = src // silence unused warning — used below
-        let down = CGEvent(keyboardEventSource: src, virtualKey: code, keyDown: true)
-        let up   = CGEvent(keyboardEventSource: src, virtualKey: code, keyDown: false)
-        down?.flags = .maskControl
-        up?.flags = .maskControl
-        down?.post(tap: .cghidEventTap)
-        up?.post(tap: .cghidEventTap)
+        // Don't claim success when the events can't even be constructed — the
+        // old code returned ok:true unconditionally. (Whether the space
+        // actually switches still depends on the Ctrl+number shortcut being
+        // enabled in System Settings; ok here means "keystroke posted".)
+        guard let down = CGEvent(keyboardEventSource: src, virtualKey: code, keyDown: true),
+              let up = CGEvent(keyboardEventSource: src, virtualKey: code, keyDown: false) else {
+            return SpaceSwitchResult(
+                ok: false, targetIndex: index, method: "ctrl_number",
+                error: "failed to construct key events"
+            )
+        }
+        down.flags = .maskControl
+        up.flags = .maskControl
+        down.post(tap: .cghidEventTap)
+        up.post(tap: .cghidEventTap)
         return SpaceSwitchResult(
             ok: true,
             targetIndex: index,

--- a/Sources/MacControlMCP/SystemInfoController.swift
+++ b/Sources/MacControlMCP/SystemInfoController.swift
@@ -327,7 +327,10 @@ actor SystemInfoController {
             )
         }
 
-        let enabled = (root["controller_properties"] as? [String: Any])?["controller_state"] as? String == "on_state"
+        // system_profiler reports controller_state as "attrib_on"/"attrib_off"
+        // (verified on macOS 14/15), not "on_state" — the old literal never
+        // matched, so bluetooth always reported disabled.
+        let enabled = (root["controller_properties"] as? [String: Any])?["controller_state"] as? String == "attrib_on"
         var devices: [BluetoothSummary.Device] = []
 
         func collect(from dict: [String: Any], connected: Bool) {

--- a/Sources/MacControlMCP/SystemInfoController.swift
+++ b/Sources/MacControlMCP/SystemInfoController.swift
@@ -366,11 +366,12 @@ actor SystemInfoController {
     }
 
     func diskUsage() -> Result<DiskUsage> {
-        // `df -g -P` — POSIX output, GB blocks, single-line per volume even
-        // for long mount names. The -P flag is critical: without it, mount
-        // names with whitespace land on multi-line records that the old
-        // whitespace-split parser broke on (Codex finding).
-        let r = ProcessRunner.run("/bin/df", ["-g", "-P"], timeout: 3)
+        // `df -k -P` — POSIX output, 1024-byte (KB) blocks, single-line per
+        // volume even for long mount names. We use -k instead of -g because
+        // macOS df -g returns 1024-byte blocks despite the name, which caused
+        // fields named *GB to contain raw KB values (~1M× too large).
+        // Divide by 1024² here to produce real GB with 2 decimal precision.
+        let r = ProcessRunner.run("/bin/df", ["-k", "-P"], timeout: 3)
         guard r.ok else {
             return Result(
                 ok: false, data: nil,
@@ -387,9 +388,11 @@ actor SystemInfoController {
             let cols = splitMaxFields(String(line), max: 6)
             guard cols.count >= 6 else { continue }
             let name = cols[0]
-            let total = Double(cols[1]) ?? 0
-            let used = Double(cols[2]) ?? 0
-            let avail = Double(cols[3]) ?? 0
+            let kbToGB = 1024.0 * 1024.0
+            func toGB(_ kb: Double) -> Double { (kb / kbToGB * 100).rounded() / 100 }
+            let total = toGB(Double(cols[1]) ?? 0)
+            let used  = toGB(Double(cols[2]) ?? 0)
+            let avail = toGB(Double(cols[3]) ?? 0)
             let usedPct = Double(cols[4].replacingOccurrences(of: "%", with: "")) ?? 0
             let mount = cols[5]
             guard mount.hasPrefix("/") && !mount.hasPrefix("/System/Volumes/VM") &&

--- a/Sources/MacControlMCP/Tools+V2.swift
+++ b/Sources/MacControlMCP/Tools+V2.swift
@@ -1,5 +1,6 @@
 import Foundation
 import ApplicationServices
+import AppKit
 
 // MARK: - Tool definitions (v0.2.0)
 
@@ -119,12 +120,11 @@ extension ToolRegistry {
         ),
         MCPToolDefinition(
             name: "list_menu_titles",
-            description: "List top-level menubar titles for an app — useful for discovery before click_menu_path.",
+            description: "List top-level menubar titles for an app — useful for discovery before click_menu_path. Omit pid to use the frontmost app.",
             inputSchema: schema(
                 properties: [
                     "pid": .object(["type": .array([.string("integer"), .string("string")])])
-                ],
-                required: ["pid"]
+                ]
             )
         ),
         MCPToolDefinition(
@@ -470,8 +470,16 @@ extension ToolRegistry {
     }
 
     func callListMenuTitles(_ arguments: [String: JSONValue]) async -> ToolCallResult {
-        guard let pid = parsePID(arguments["pid"]) else {
-            return invalidArgument("list_menu_titles requires a positive integer pid.")
+        let pid: pid_t
+        if let provided = parsePID(arguments["pid"]) {
+            pid = provided
+        } else if arguments["pid"] == nil {
+            guard let app = NSWorkspace.shared.frontmostApplication else {
+                return errorResult("No frontmost application found.", ["ok": .bool(false)])
+            }
+            pid = app.processIdentifier
+        } else {
+            return invalidArgument("list_menu_titles: pid must be a positive integer.")
         }
         let titles = await menus.topLevelTitles(pid: pid)
         return successResult(

--- a/Sources/MacControlMCP/Tools+V2Phase2.swift
+++ b/Sources/MacControlMCP/Tools+V2Phase2.swift
@@ -191,6 +191,15 @@ extension ToolRegistry {
             return invalidArgument(String(describing: error))
         }
 
+        // Region is all-or-nothing. A partial/malformed spec (e.g. x+y+width
+        // but no height) previously fell through to a full-display capture and
+        // still reported success — silently ignoring the caller's intent.
+        let regionKeys = ["x", "y", "width", "height"]
+        let present = regionKeys.filter { arguments[$0] != nil }
+        if !present.isEmpty && present.count < regionKeys.count {
+            return invalidArgument("capture_screen region requires all of x, y, width, height together (or omit all for the full display). Got: \(present.joined(separator: ", ")).")
+        }
+
         do {
             let capture: ScreenController.CaptureResult
             if let x = arguments["x"]?.intValue,
@@ -198,8 +207,10 @@ extension ToolRegistry {
                let w = arguments["width"]?.intValue,
                let h = arguments["height"]?.intValue {
                 capture = try await screen.captureRegion(x: x, y: y, width: w, height: h, outputPath: outputPath)
-            } else {
+            } else if present.isEmpty {
                 capture = try await screen.captureDisplay(outputPath: outputPath)
+            } else {
+                return invalidArgument("capture_screen region values (x, y, width, height) must be integers.")
             }
 
             return successResult(

--- a/Sources/MacControlMCP/Tools+V2Phase5.swift
+++ b/Sources/MacControlMCP/Tools+V2Phase5.swift
@@ -742,6 +742,12 @@ extension ToolRegistry {
         }
         let role = arguments["role"]?.stringValue
         let title = arguments["title"]?.stringValue
+        // Require a real target. With both omitted, findElement matches the
+        // first element (the app root) on attempt 0, so the tool reported
+        // "visible after 0 scroll(s)" without scrolling or finding anything.
+        guard (role?.isEmpty == false) || (title?.isEmpty == false) else {
+            return invalidArgument("scroll_to_element requires at least one of 'role' or 'title'.")
+        }
         let maxScrolls = max(1, min(arguments["max_scrolls"]?.intValue ?? 30, 200))
 
         for attempt in 0..<maxScrolls {

--- a/Sources/MacControlMCP/Tools+V2Phase9.swift
+++ b/Sources/MacControlMCP/Tools+V2Phase9.swift
@@ -260,6 +260,16 @@ extension ToolRegistry {
         }
         let maxDepth = max(1, min(arguments["max_depth"]?.intValue ?? 12, 32))
         let r = await axSnapshot.capture(pid: pid, maxDepth: maxDepth)
+        // 0 nodes means the AX root itself was unreadable (missing
+        // Accessibility permission or a dead/UI-less pid) — every app has at
+        // least a root + window. Reporting success here produced garbage
+        // snapshots and false "no changes" diffs.
+        guard r.nodeCount > 0 else {
+            return errorResult(
+                "ax_snapshot_capture read 0 nodes for pid \(pid); the AX tree is unreadable (grant Accessibility permission, or the process has no UI).",
+                ["ok": .bool(false), "pid": .number(Double(pid)), "node_count": .number(0)]
+            )
+        }
         return successResult("snapshot \(r.snapshotID) captured, \(r.nodeCount) nodes",
                              ["ok": .bool(true), "result": encodeAsJSONValue(r)])
     }
@@ -291,16 +301,26 @@ extension ToolRegistry {
             bundleId: arguments["bundle_id"]?.stringValue,
             tier: nil,
             result: arguments["result"]?.stringValue,
-            metadata: nil // v0.6.0: simple string payloads; extend later
+            metadata: arguments["metadata"]?.objectValue
         )
         return successResult("audit entry appended",
                              ["ok": .bool(true), "event": .string(event)])
     }
 
     func callAuditLogRead(_ arguments: [String: JSONValue]) async -> ToolCallResult {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        let since = arguments["since_iso"]?.stringValue.flatMap { formatter.date(from: $0) }
+        // Parse since_iso tolerantly: standard ISO-8601 without fractional
+        // seconds (e.g. "2026-07-06T10:00:00Z") must still work. The old
+        // formatter required fractional seconds, so those inputs silently
+        // parsed to nil and the since filter was dropped entirely.
+        func parseISO(_ s: String) -> Date? {
+            let withFrac = ISO8601DateFormatter()
+            withFrac.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let d = withFrac.date(from: s) { return d }
+            let plain = ISO8601DateFormatter()
+            plain.formatOptions = [.withInternetDateTime]
+            return plain.date(from: s)
+        }
+        let since = arguments["since_iso"]?.stringValue.flatMap(parseISO)
         let filterTool = arguments["filter_tool"]?.stringValue
         let filterEvent = arguments["filter_event"]?.stringValue
         let limit = arguments["limit"]?.intValue ?? 500

--- a/Sources/MacControlMCP/VoiceController.swift
+++ b/Sources/MacControlMCP/VoiceController.swift
@@ -21,6 +21,33 @@ import Speech
 ///
 /// All paths that touch TCC degrade gracefully with a structured
 /// `{ok:false, hint: "..."}` result rather than crashing.
+/// Keeps `AVSpeechSynthesizer` instances alive for the duration of an
+/// utterance. `text_to_speech` speak-mode created a local synthesizer that
+/// was deallocated the moment the call returned, cancelling speech before a
+/// word came out (while still reporting ok:true). This retains each
+/// synthesizer until its delegate reports the utterance finished/cancelled.
+@MainActor
+final class SpeechRetainer: NSObject, @preconcurrency AVSpeechSynthesizerDelegate {
+    static let shared = SpeechRetainer()
+    // Keyed by ObjectIdentifier (Sendable) so the nonisolated delegate
+    // callbacks can schedule removal without capturing the non-Sendable
+    // synthesizer across the actor hop.
+    private var active: [ObjectIdentifier: AVSpeechSynthesizer] = [:]
+
+    func speak(_ utterance: AVSpeechUtterance, with synth: AVSpeechSynthesizer) {
+        synth.delegate = self
+        active[ObjectIdentifier(synth)] = synth
+        synth.speak(utterance)
+    }
+
+    func speechSynthesizer(_ synth: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
+        active.removeValue(forKey: ObjectIdentifier(synth))
+    }
+    func speechSynthesizer(_ synth: AVSpeechSynthesizer, didCancel utterance: AVSpeechUtterance) {
+        active.removeValue(forKey: ObjectIdentifier(synth))
+    }
+}
+
 actor VoiceController {
 
     public struct SpeechResult: Codable, Sendable {
@@ -167,7 +194,10 @@ actor VoiceController {
                 error: r.ok ? nil : r.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
             )
         }
-        // Speak aloud via AVSpeechSynthesizer on the main actor.
+        // Speak aloud via AVSpeechSynthesizer on the main actor. The
+        // synthesizer is retained by SpeechRetainer until the utterance
+        // finishes — a local instance would be deallocated immediately,
+        // cancelling speech before anything is heard.
         let synthesisError = await MainActor.run { () -> String? in
             let synth = AVSpeechSynthesizer()
             let utterance = AVSpeechUtterance(string: text)
@@ -176,7 +206,7 @@ actor VoiceController {
                    ?? AVSpeechSynthesisVoice(language: voice) {
                 utterance.voice = avVoice
             }
-            synth.speak(utterance)
+            SpeechRetainer.shared.speak(utterance, with: synth)
             return nil
         }
         return SynthesisResult(ok: synthesisError == nil, mode: "speak",

--- a/Tests/MacControlMCPTests/AuditLogFixesTests.swift
+++ b/Tests/MacControlMCPTests/AuditLogFixesTests.swift
@@ -1,0 +1,62 @@
+import Testing
+import Foundation
+@testable import MacControlMCP
+
+@Suite("audit_log fixes — ordering, metadata, tolerant since", .serialized)
+struct AuditLogFixesTests {
+
+    private func text(_ r: ToolCallResult, _ key: String) -> String? {
+        guard case .object(let o) = r.structuredContent else { return nil }
+        if case .string(let s) = o[key] ?? .null { return s }
+        return nil
+    }
+
+    @Test("read returns newest-first, preserves metadata, and honors a no-fraction since")
+    func auditRoundTrip() async {
+        let registry = ToolRegistry(accessibility: AccessibilityController())
+        let tag = "evt-\(UUID().uuidString.prefix(8))"
+
+        // Append two entries in order; the second is newer.
+        _ = await registry.callTool(name: "audit_log_append",
+            arguments: ["event": .string(tag), "tool": .string("first")])
+        _ = await registry.callTool(name: "audit_log_append",
+            arguments: ["event": .string(tag), "tool": .string("second"),
+                        "metadata": .object(["k": .string("v")])])
+
+        let read = await registry.callTool(name: "audit_log_read",
+            arguments: ["filter_event": .string(tag)])
+        #expect(read.isError == false)
+        guard case .object(let payload) = read.structuredContent,
+              case .array(let entries) = payload["entries"] ?? .null else {
+            Issue.record("audit_log_read returned no entries array"); return
+        }
+        #expect(entries.count == 2)
+
+        // Newest-first: the second append (tool == "second") must be at [0].
+        if case .object(let newest) = entries.first ?? .null,
+           case .string(let tool) = newest["tool"] ?? .null {
+            #expect(tool == "second")
+            // metadata survived the append (was previously discarded).
+            if case .object(let meta) = newest["metadata"] ?? .null,
+               case .string(let v) = meta["k"] ?? .null {
+                #expect(v == "v")
+            } else {
+                Issue.record("metadata not persisted on the appended entry")
+            }
+        } else {
+            Issue.record("newest entry missing or malformed")
+        }
+
+        // A since filter WITHOUT fractional seconds must still parse and apply
+        // (previously it silently parsed to nil and returned everything).
+        let future = "2999-01-01T00:00:00Z"
+        let filtered = await registry.callTool(name: "audit_log_read",
+            arguments: ["filter_event": .string(tag), "since_iso": .string(future)])
+        if case .object(let p2) = filtered.structuredContent,
+           case .array(let e2) = p2["entries"] ?? .null {
+            #expect(e2.isEmpty, "a far-future since must filter out all past entries")
+        } else {
+            Issue.record("second audit_log_read malformed")
+        }
+    }
+}


### PR DESCRIPTION
## PR-2 of 3 — silent no-ops (reports ok, does nothing/wrong)

**Stacked on PR-1** (`fix/critical-crashes-and-osascript-deadlock`) — review/merge #3 first, or review the [batch commits](../commits/fix/silent-no-ops) directly. Base retargets to `main` once PR-1 lands.

The worst class for an agent: tools that return `ok:true` while doing nothing or the wrong thing. 14 of the 19 Phase-2 findings, plus carried-forward prior WIP.

### Fixed (14)
**Wrong result reported as success**
- `bluetooth_devices` always reported `enabled=false` — `controller_state` is `attrib_on` (verified via `system_profiler`), not `on_state`.
- `night_shift_set` toggle could never turn **off** — it checked nightlight status for `"enabled"`, which nightlight never prints.
- `invoke_app_intent` with input **always failed** — `shortcuts run` has no `--input` flag; stage the text in a temp file, pass `--input-path`.
- `set_brightness` direction posted CGKeyCodes 144/145 (not the brightness keys) → no change but `ok:true`. Now posts `NX_KEYTYPE_BRIGHTNESS_UP/DOWN` system-defined events.
- `text_to_speech` speak mode **never spoke** — the local `AVSpeechSynthesizer` was deallocated the instant the call returned. Now retained until the utterance finishes.
- `switch_to_space` returned `ok:true` even when the key events couldn't be constructed. Guarded.
- `ax_snapshot_capture` reported success on an **unreadable** AX tree (0 nodes → missing permission / dead pid). Now errors with a hint.

**Silently dropped / discarded data**
- `ax_snapshot_diff` missed value changes on checkboxes/sliders/steppers/radios (their `kAXValue` is a number/bool that the string-only getter dropped).
- `audit_log_read` returned oldest-first despite documenting newest-first; and dropped a `since_iso` without fractional seconds (parsed to nil). `audit_log_append` silently discarded its advertised `metadata` param.
- `reminders_list` dropped any reminder whose title contained `", "` and applied `limit` per-list instead of globally.
- `capture_screen` with a partial region (e.g. x+y+width, no height) silently captured the full display. Now all-or-nothing.
- `scroll_to_element` with both role+title omitted matched the app root on attempt 0 ("visible after 0 scrolls"). Now requires a target.

### Carried-forward prior WIP (first commit)
Pre-existing uncommitted working-tree changes, committed as-is so the fixes above had a clean base: `searchContacts` → `CNContactStore`; `diskUsage` → `df -k`; `list_menu_titles` frontmost fallback.

### Verification
177 tests pass (1 new audit-log regression: newest-first ordering, metadata round-trip, tolerant `since`). Real store confirmed untouched.

### Deferred to a follow-up (5-6) — need architectural work or on-device UI/HW verification
- `undo_last_action`/`undo_peek` are **dead** — `UndoController.push` has zero call sites; wiring undo into every mutating tool is its own change.
- `enableManualAccessibility` leaves `AXEnhancedUserInterface=true` (can perturb AX window positioning) — needs save/restore.
- `pasteTextViaClipboard` restores the clipboard 50 ms after Cmd+V (race under load).
- `mail_send` draft mode; `notification_center` toggle reliability; `contacts_search` word-prefix (largely mooted by the CNContactStore move).

### Manual smoke
`night_shift_set` toggle (needs nightlight installed), `set_brightness up/down`, `text_to_speech` speak, `switch_to_space`, `ax_snapshot_diff` on a checkbox toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
