### PR TITLE
fix: AppleScript escaping + Retina display scale (bug-hunt PR-3/3, partial)

### DIFF
--- a/Sources/MacControlMCP/AppleAppsController.swift
+++ b/Sources/MacControlMCP/AppleAppsController.swift
@@ -54,10 +54,11 @@ actor AppleAppsController {
     /// Returns `ok:false` with the AppleScript stderr if Messages rejects
     /// the recipient (unknown contact, not iMessage-reachable, offline).
     func sendMessage(to: String, body: String) -> Result<MessageSent> {
-        let escTo = to.replacingOccurrences(of: "\"", with: "\\\"")
-        let escBody = body
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
+        // Both must escape backslash + quote; the recipient escaping used to
+        // omit the backslash pass, so a recipient containing "\" broke or
+        // could inject into the script.
+        let escTo = AppleScriptString.escape(to)
+        let escBody = AppleScriptString.escape(body)
         // Uses `send ... to buddy` which targets iMessage by default. Service
         // is auto-resolved so the same script works for both phone and email.
         let script = """

--- a/Sources/MacControlMCP/AppleScriptString.swift
+++ b/Sources/MacControlMCP/AppleScriptString.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Escaping for values interpolated into AppleScript double-quoted string
+/// literals.
+///
+/// Order matters: the backslash must be escaped **first**, then the double
+/// quote. Escaping the quote first would turn `"` into `\"`, and the
+/// subsequent backslash pass would then double-escape that new backslash into
+/// `\\"`, breaking the literal. Several call sites had hand-rolled escapers
+/// that omitted the backslash pass entirely, so a value containing a backslash
+/// (or `\"`) broke — or could inject into — the surrounding AppleScript.
+enum AppleScriptString {
+    static func escape(_ s: String) -> String {
+        s.replacingOccurrences(of: "\\", with: "\\\\")
+         .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+}

--- a/Sources/MacControlMCP/DisplayController.swift
+++ b/Sources/MacControlMCP/DisplayController.swift
@@ -27,9 +27,15 @@ actor DisplayController {
         let mainID = CGMainDisplayID()
         return ids.enumerated().map { index, id in
             let bounds = CGDisplayBounds(id)
-            // Pixel dimensions vs point dimensions — scale factor = px/pt
-            let pixelWidth = Double(CGDisplayPixelsWide(id))
-            let scale = pixelWidth / bounds.width
+            // Backing scale = real pixels / points. CGDisplayPixelsWide returns
+            // POINTS in a HiDPI scaled mode, so px/pt collapsed to 1.0 on every
+            // Retina display. The current mode's pixelWidth is the true backing
+            // pixel count; divide by the point width for the real scale.
+            let scale: Double = {
+                guard let mode = CGDisplayCopyDisplayMode(id) else { return 1.0 }
+                let pt = Double(mode.width)
+                return pt > 0 ? Double(mode.pixelWidth) / pt : 1.0
+            }()
             return DisplayInfo(
                 id: UInt32(id),
                 index: index,

--- a/Sources/MacControlMCP/FinderController.swift
+++ b/Sources/MacControlMCP/FinderController.swift
@@ -241,7 +241,9 @@ actor FinderController {
         // AppleScript's `tell application "Finder" to delete` moves to Trash.
         // It's the only sanctioned way; `mv ~/.Trash/` breaks Finder's
         // "Put Back" feature.
-        let escaped = canonical.replacingOccurrences(of: "\"", with: "\\\"")
+        // Escape backslash + quote; the old code omitted the backslash pass,
+        // so a path containing "\" targeted the wrong file or failed.
+        let escaped = AppleScriptString.escape(canonical)
         let script = """
         tell application "Finder" to delete POSIX file "\(escaped)"
         """

--- a/Tests/MacControlMCPTests/AppleScriptStringTests.swift
+++ b/Tests/MacControlMCPTests/AppleScriptStringTests.swift
@@ -1,0 +1,18 @@
+import Testing
+@testable import MacControlMCP
+
+@Suite("AppleScriptString.escape")
+struct AppleScriptStringTests {
+    @Test("escapes backslash before quote (order matters)")
+    func ordering() {
+        // A lone backslash becomes two backslashes.
+        #expect(AppleScriptString.escape(#"a\b"#) == #"a\\b"#)
+        // A lone quote becomes escaped-quote.
+        #expect(AppleScriptString.escape("a\"b") == "a\\\"b")
+        // Backslash + quote: backslash doubles first, then the quote escapes —
+        // the reversed order would have produced a broken \\" sequence.
+        #expect(AppleScriptString.escape("\\\"") == "\\\\\\\"")
+        // Plain text is unchanged.
+        #expect(AppleScriptString.escape("hello world") == "hello world")
+    }
+}


### PR DESCRIPTION
## PR-3 of 3 — escaping & coordinates (partial)

**Stacked on PR-2** (`fix/silent-no-ops`). Review order: #3 → #4 → this.

This is a partial PR-3: the two items I could fix **and verify** cleanly. The rest of Phase 3 (Retina grounding, misc logic) is deferred with a precise plan below — I'm not shipping unverified coordinate transforms into the tool's core grounding path.

### Fixed & verified (3 findings)
- **AppleScript-literal escaping** (`imessage_send` recipient, `trash_file` path): both escaped only the double quote, not the backslash — a value containing `\` broke the surrounding AppleScript (correctness + an injection surface). New shared `AppleScriptString.escape` (backslash first, then quote); both sites routed through it. Unit-tested.
- **`list_displays` scale on Retina**: reported `1.0` on every Retina display because `CGDisplayPixelsWide` returns *points* in a HiDPI mode. Now uses the display mode's `pixelWidth/width`. **Verified on this machine: old 1.0 → new 2.0.**

### Verification
178 tests pass (1 new: escaping order). Real store untouched.

### Deferred — Retina grounding (2 HIGH) needs on-device verification
`ground()` and `ax_tree_augmented` return OCR coordinates in **capture-image pixels**, ~2× off in point-based click space on Retina. The fix is to divide OCR block coords by the backing scale (now correctly available from `DisplayController`, =2.0 here) before returning them — but verifying the transform (direction + which display) requires a real OCR capture and a click against a known on-screen target, which can't be done reliably headlessly. Applying it blind risks making grounding worse. Same class: `ScreenCaptureKitBridge` mixes CG (top-left) and Cocoa (bottom-left) frame origins.

### Remaining Phase-3 misc-logic (clean, ~9) for a follow-up
`imessage_list_recent` participant grouping; contacts company-name empty; `permissions_status` location always-missing; `wait_for_file_dialog` AXSheet-only; `press_key_sequence` delay clamp; `file_dialog_select_item` wrong-app; `capture_screen_v2` temp-file leak on artifact-store failure; `list_menu_titles` explicit-`null`; `set_focus_mode` case inversion; `ax_snapshot_capture` skips `enableManualAccessibility` (empty Electron/iWork snapshots).

### Also deferred from Phase-2 (architectural)
`undo_last_action`/`undo_peek` dead (`UndoController.push` unwired); `enableManualAccessibility` `AXEnhancedUserInterface` save/restore; `pasteTextViaClipboard` 50 ms restore race; `mail_send` draft; `notification_center` toggle reliability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
