### PR TITLE
fix: misc-logic — focus mode, permissions, contacts, iMessage, dialogs

### DIFF
--- a/Sources/MacControlMCP/AppleAppsController.swift
+++ b/Sources/MacControlMCP/AppleAppsController.swift
@@ -101,14 +101,18 @@ actor AppleAppsController {
                     set p to (participants of thisChat)
                     set nameList to ""
                     repeat with px in p
-                        set nameList to nameList & (handle of px) & ", "
+                        if nameList is not "" then set nameList to nameList & ", "
+                        set nameList to nameList & (handle of px)
                     end repeat
                     set end of out to nameList
                 on error
                     set end of out to "(unknown)"
                 end try
             end repeat
-            return out
+            set AppleScript's text item delimiters to "§§REC§§"
+            set outStr to out as string
+            set AppleScript's text item delimiters to ""
+            return outStr
         end tell
         """
         let r = OsascriptRunner.run(script)
@@ -116,12 +120,14 @@ actor AppleAppsController {
             return Result(ok: false, data: nil,
                           error: r.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
         }
-        // AppleScript returns a comma-separated list when the outer value is
-        // a list. Each entry in our script ends with ", " — we split on
-        // that outer boundary, then strip trailing commas.
+        // One record per chat, joined by a sentinel. The old code split the
+        // whole output on "," — the same "," used between participants — so a
+        // group chat's participants each became a separate "thread" and the
+        // count was wrong. Split on the record sentinel instead; each thread's
+        // participant string keeps all its handles intact.
         let text = r.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         let entries = text
-            .split(separator: ",", omittingEmptySubsequences: false)
+            .components(separatedBy: "§§REC§§")
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty && $0 != "(unknown)" }
         let threads = entries.map { RecentThread(participant: $0, lastMessagePreview: nil) }
@@ -457,6 +463,7 @@ actor AppleAppsController {
         let keys: [CNKeyDescriptor] = [
             CNContactGivenNameKey as CNKeyDescriptor,
             CNContactFamilyNameKey as CNKeyDescriptor,
+            CNContactOrganizationNameKey as CNKeyDescriptor,
             CNContactPhoneNumbersKey as CNKeyDescriptor,
             CNContactEmailAddressesKey as CNKeyDescriptor,
         ]
@@ -464,8 +471,11 @@ actor AppleAppsController {
         do {
             let raw = try store.unifiedContacts(matching: predicate, keysToFetch: keys)
             let contacts: [Contact] = raw.prefix(cap).map { c in
-                let name = "\(c.givenName) \(c.familyName)"
+                // Company/organization contacts have no given/family name —
+                // fall back to the org name so they aren't returned nameless.
+                var name = "\(c.givenName) \(c.familyName)"
                     .trimmingCharacters(in: .whitespaces)
+                if name.isEmpty { name = c.organizationName }
                 let phones = c.phoneNumbers.map { $0.value.stringValue }
                 let emails = c.emailAddresses.map { String($0.value) }
                 return Contact(name: name, phones: phones, emails: emails)

--- a/Sources/MacControlMCP/FileDialogController.swift
+++ b/Sources/MacControlMCP/FileDialogController.swift
@@ -134,9 +134,13 @@ actor FileDialogController {
         }
 
         // 2 + 3. scan regular running apps for a visible sheet/dialog.
-        let apps = NSWorkspace.shared.runningApplications.filter {
-            $0.activationPolicy == .regular && $0.processIdentifier > 0
-        }
+        // Check the frontmost app first. Scanning all apps in arbitrary order
+        // could return a background app's dialog instead of the one the user
+        // is actually interacting with.
+        let frontPid = NSWorkspace.shared.frontmostApplication?.processIdentifier
+        let apps = NSWorkspace.shared.runningApplications
+            .filter { $0.activationPolicy == .regular && $0.processIdentifier > 0 }
+            .sorted { a, _ in a.processIdentifier == frontPid }
         for app in apps {
             let appElement = AXUIElementCreateApplication(app.processIdentifier)
             if let hit = firstDialog(in: appElement) {

--- a/Sources/MacControlMCP/HardwareController.swift
+++ b/Sources/MacControlMCP/HardwareController.swift
@@ -386,7 +386,9 @@ actor HardwareController {
         case "sleep":
             cmd = state.lowercased() == "on" ? "Turn Sleep Focus On" : "Turn Sleep Focus Off"
         default:
-            cmd = "Turn \(mode) Focus \(state == "on" ? "On" : "Off")"
+            // Was `state == "on"` (case-sensitive) while every named case
+            // lowercased first, so "On"/"ON" flipped a custom mode to Off.
+            cmd = "Turn \(mode) Focus \(state.lowercased() == "on" ? "On" : "Off")"
         }
         let r = ProcessRunner.run("/usr/bin/shortcuts", ["run", cmd], timeout: 8)
         if r.ok {

--- a/Sources/MacControlMCP/Tools+V2.swift
+++ b/Sources/MacControlMCP/Tools+V2.swift
@@ -471,15 +471,19 @@ extension ToolRegistry {
 
     func callListMenuTitles(_ arguments: [String: JSONValue]) async -> ToolCallResult {
         let pid: pid_t
-        if let provided = parsePID(arguments["pid"]) {
+        let pidArg = arguments["pid"]
+        if let pidArg, pidArg != .null {
+            // A real value was supplied — it must be a valid positive integer.
+            guard let provided = parsePID(pidArg) else {
+                return invalidArgument("list_menu_titles: pid must be a positive integer.")
+            }
             pid = provided
-        } else if arguments["pid"] == nil {
+        } else {
+            // Omitted OR explicit null → frontmost app, matching list_windows.
             guard let app = NSWorkspace.shared.frontmostApplication else {
                 return errorResult("No frontmost application found.", ["ok": .bool(false)])
             }
             pid = app.processIdentifier
-        } else {
-            return invalidArgument("list_menu_titles: pid must be a positive integer.")
         }
         let titles = await menus.topLevelTitles(pid: pid)
         return successResult(
@@ -536,7 +540,13 @@ extension ToolRegistry {
             ("location", location),
             ("microphone", microphone)
         ]
-        .filter { !["granted", "granted_when_in_use", "granted_always", "granted_legacy", "write_only", "authorized_legacy", "limited"].contains($0.1) }
+        .filter { (_, status) in
+            let granted: Set<String> = ["granted", "granted_when_in_use", "granted_always", "granted_legacy", "write_only", "authorized_legacy", "limited"]
+            // `location` can only report system-wide services state
+            // ("system_enabled …"); the old exact-match whitelist had no such
+            // string, so location was always listed as missing even when on.
+            return !(granted.contains(status) || status.hasPrefix("granted") || status.hasPrefix("system_enabled"))
+        }
         .map { $0.0 }
 
         let summary = missing.isEmpty

--- a/Sources/MacControlMCP/Tools+V2Phase10.swift
+++ b/Sources/MacControlMCP/Tools+V2Phase10.swift
@@ -232,6 +232,10 @@ extension ToolRegistry {
         do {
             let tmpDir = NSTemporaryDirectory()
             let tmpPath = tmpDir + "mc-\(Int(Date().timeIntervalSince1970)).png"
+            // Clean up the temp capture on every exit — the old code removed it
+            // only on the success path, so a storeImage failure leaked a
+            // full-resolution screenshot into the temp dir.
+            defer { try? FileManager.default.removeItem(atPath: tmpPath) }
             let capture = try await screen.captureDisplay(outputPath: tmpPath)
             guard let artifact = await artifactStore.storeImage(
                 sourcePath: capture.path,
@@ -239,11 +243,10 @@ extension ToolRegistry {
                 maxDimension: maxDim
             ) else {
                 return errorResult(
-                    "image exceeds max_bytes=\(maxBytes) even after downscale — try smaller max_dimension",
+                    "artifact store rejected the image (likely exceeds max_bytes=\(maxBytes) even after downscale — try a smaller max_dimension)",
                     ["ok": .bool(false)]
                 )
             }
-            try? FileManager.default.removeItem(atPath: tmpPath)
             var payload: [String: JSONValue] = [
                 "ok": .bool(true),
                 "content_ref": .string(artifact.contentRef),

--- a/Sources/MacControlMCP/Tools+V2Phase5.swift
+++ b/Sources/MacControlMCP/Tools+V2Phase5.swift
@@ -525,7 +525,10 @@ extension ToolRegistry {
             parsed.append((code, flags))
         }
 
-        let delayMs = max(0, arguments["delay_ms"]?.intValue ?? 30)
+        // Clamp the upper bound: delay_ms drives a Thread.sleep inside the
+        // AccessibilityController actor, so a huge value would pin a
+        // cooperative-pool thread for the whole duration.
+        let delayMs = min(max(0, arguments["delay_ms"]?.intValue ?? 30), 5_000)
         let ok = await accessibility.pressKeySequence(parsed, delay: TimeInterval(delayMs) / 1000.0)
         return ok
             ? successResult("Pressed \(parsed.count) step(s).", [


### PR DESCRIPTION
## Misc-logic fixes (bug-hunt follow-up)

8 of the ~9 clean Phase-3 misc-logic findings, off updated `main` (PRs #3/#6/#5 already merged).

### Fixed (8)
- **`set_focus_mode`** inverted on/off for **custom** modes — the default case compared `state` case-sensitively while every named case lowercased first, so `"On"`/`"ON"` flipped a custom mode *off*.
- **`permissions_status`** always listed `location` as missing — the location helper only returns `"system_enabled …"`, which the exact-match granted whitelist never contained.
- **`press_key_sequence`** `delay_ms` had no upper clamp (drives `Thread.sleep` inside an actor) → clamp `[0, 5000]`.
- **`list_menu_titles`** rejected an explicit `"pid": null` instead of falling back to the frontmost app (diverged from `list_windows`).
- **`capture_screen_v2`** leaked the full-res temp screenshot when the artifact store failed (cleanup only on success) → `defer`.
- **`contacts_search`** returned empty names for company/org contacts (only given+family fetched) → fall back to `organizationName`.
- **`imessage_list_recent`** flattened each participant into its own "thread" (split the whole output on `,`, the same separator between participants) → record sentinel keeps each chat one thread.
- **`file_dialog_select_item`** could grab a background app's dialog → check the frontmost app first.

### Not included — `wait_for_file_dialog` (deferred)
Turned out not clean: it only matches `AXSheet` and misses standalone Open/Save dialog *windows*. The sibling `FileDialogController` already handles both, but its detection (`firstDialog`/`isDialogWindow`) is private — reusing it needs public plumbing, and a bolt-on heuristic would be fragile and can't be verified without a real Open/Save panel. Left for a focused change.

### Verification
178 tests pass; real store untouched. These are integration-bound (Contacts/Messages/permissions/shortcuts/dialogs), so verified by build + code reasoning — **manual smoke** recommended per tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
