### PR TITLE
fix: Retina grounding OCR coords 2x off (pixel vs point space)

### DIFF
--- a/Sources/MacControlMCP/GroundingController.swift
+++ b/Sources/MacControlMCP/GroundingController.swift
@@ -161,17 +161,49 @@ actor GroundingController {
         )
     }
 
+    /// Convert an OCR block's center from image-pixel space to global
+    /// screen POINTS.
+    ///
+    /// `ScreenController.ocr` emits block coordinates in **image pixels**:
+    /// a full-screen capture on a 2× Retina display is 3024×1964px for a
+    /// 1512×982pt display, so a block center at pixel (300,240) sits at
+    /// point (150,120). AX frames and click targets are in points, so OCR
+    /// centers MUST be scaled down by the backing factor before they are
+    /// used as click coordinates (`ground`) or compared against AX rects
+    /// (`axTreeAugmented`) — otherwise every OCR hit is 2× off on Retina.
+    ///
+    /// The scale is derived from the actual captured image dimensions vs
+    /// the display's point dimensions, so it is exact for any backing
+    /// factor (2.0 or a fractional scaled mode) and collapses to identity
+    /// on a 1× display. Zero/missing dimensions fall back to identity so
+    /// the conversion can never divide by zero.
+    static func ocrPixelCenterToPoints(
+        blockX: Double, blockY: Double, blockW: Double, blockH: Double,
+        imagePixelWidth: Int, imagePixelHeight: Int,
+        displayPointWidth: Double, displayPointHeight: Double
+    ) -> CGPoint {
+        let centerX = blockX + blockW / 2
+        let centerY = blockY + blockH / 2
+        let sx = imagePixelWidth > 0 ? displayPointWidth / Double(imagePixelWidth) : 1
+        let sy = imagePixelHeight > 0 ? displayPointHeight / Double(imagePixelHeight) : 1
+        return CGPoint(x: centerX * sx, y: centerY * sy)
+    }
+
     private func ocrLookup(target: String) async -> [Candidate] {
         // Use the screen controller's OCR pass. The OCR result contains
-        // blocks with bounding boxes; we find the block whose text best
-        // matches the target.
+        // blocks with bounding boxes in image PIXELS; we find the block
+        // whose text best matches the target and convert its center to
+        // global screen points so the caller can click it directly.
+        let capture: ScreenController.CaptureResult
         let ocrBlocks: [ScreenController.OCRBlock]
         do {
-            let (_, result) = try await screen.captureAndOCR(keepImage: false)
+            let (cap, result) = try await screen.captureAndOCR(keepImage: false)
+            capture = cap
             ocrBlocks = result.blocks
         } catch {
             return []
         }
+        let bounds = CGDisplayBounds(CGMainDisplayID())
         let needle = target.lowercased()
         var out: [Candidate] = []
         for block in ocrBlocks {
@@ -179,12 +211,17 @@ actor GroundingController {
             let exact = text == needle
             let contains = text.contains(needle)
             if !exact && !contains { continue }
-            let centerX = block.x + block.width / 2
-            let centerY = block.y + block.height / 2
+            let center = Self.ocrPixelCenterToPoints(
+                blockX: block.x, blockY: block.y,
+                blockW: block.width, blockH: block.height,
+                imagePixelWidth: capture.width, imagePixelHeight: capture.height,
+                displayPointWidth: Double(bounds.width),
+                displayPointHeight: Double(bounds.height)
+            )
             out.append(.init(
                 role: nil,
                 title: block.text,
-                x: centerX, y: centerY,
+                x: center.x, y: center.y,
                 source: "ocr",
                 confidence: exact ? 0.9 : (contains ? 0.6 : 0.3)
             ))
@@ -245,10 +282,18 @@ actor GroundingController {
             )
         }
 
-        // 2. Single OCR pass over the visible region
+        // 2. Single OCR pass over the visible region. Block coordinates
+        // come back in image PIXELS; convert their centers to global
+        // screen POINTS so the geometric join below compares like with
+        // like against AX frames (which are in points). Without this the
+        // join silently fails on Retina — pixel centers are 2× too large
+        // and fall outside every small AX rect, so only oversized
+        // containers ever match and no useful label is inferred.
+        let capture: ScreenController.CaptureResult
         let ocrBlocks: [ScreenController.OCRBlock]
         do {
-            let (_, result) = try await screen.captureAndOCR(keepImage: false)
+            let (cap, result) = try await screen.captureAndOCR(keepImage: false)
+            capture = cap
             ocrBlocks = result.blocks
         } catch {
             let ms = Int(Date().timeIntervalSince(start) * 1000)
@@ -256,6 +301,16 @@ actor GroundingController {
                 ok: false, pid: Int32(pid), nodeCount: axBoxes.count, inferredCount: 0,
                 nodes: axBoxes.map { $0.node }, elapsedMs: ms,
                 error: "OCR pass failed: \(error)"
+            )
+        }
+        let displayBounds = CGDisplayBounds(CGMainDisplayID())
+        let ocrPointCenters: [CGPoint] = ocrBlocks.map { block in
+            Self.ocrPixelCenterToPoints(
+                blockX: block.x, blockY: block.y,
+                blockW: block.width, blockH: block.height,
+                imagePixelWidth: capture.width, imagePixelHeight: capture.height,
+                displayPointWidth: Double(displayBounds.width),
+                displayPointHeight: Double(displayBounds.height)
             )
         }
 
@@ -281,11 +336,8 @@ actor GroundingController {
             // checked by comparing frame areas — the smaller containing
             // frame wins.)
             var bestOCR: (text: String, area: Double, overlapping: Bool)?
-            for block in ocrBlocks {
-                let ocrCenter = CGPoint(
-                    x: block.x + block.width / 2,
-                    y: block.y + block.height / 2
-                )
+            for (blockIndex, block) in ocrBlocks.enumerated() {
+                let ocrCenter = ocrPointCenters[blockIndex]
                 guard box.rect.contains(ocrCenter) else { continue }
 
                 // Check whether any OTHER ax box also contains this center

--- a/Sources/MacControlMCP/ScreenController.swift
+++ b/Sources/MacControlMCP/ScreenController.swift
@@ -14,6 +14,13 @@ actor ScreenController {
         let height: Int
     }
 
+    /// A single OCR text block. `x`/`y`/`width`/`height` are in IMAGE
+    /// PIXELS (top-left origin) of the captured image — i.e. backing
+    /// resolution, so 2× the point size on a Retina display. They are
+    /// consistent with the returned image's pixel dimensions (annotate /
+    /// crop use). To turn a block center into a click-ready global screen
+    /// POINT, divide by the backing scale — see
+    /// `GroundingController.ocrPixelCenterToPoints`.
     struct OCRBlock: Codable, Sendable {
         let text: String
         let confidence: Double

--- a/Sources/MacControlMCP/Tools+V2Phase2.swift
+++ b/Sources/MacControlMCP/Tools+V2Phase2.swift
@@ -67,7 +67,7 @@ extension ToolRegistry {
         ),
         MCPToolDefinition(
             name: "ocr_screen",
-            description: "Capture the screen (or a region) and run OCR. Returns joined text plus per-block coordinates and confidence.",
+            description: "Capture the screen (or a region) and run OCR. Returns joined text plus per-block coordinates and confidence. Coordinates are in IMAGE PIXELS matching image_width/image_height (i.e. backing resolution — 2x point size on Retina), for annotating/cropping the returned image. For click-ready screen points, use the `ground` tool with strategy 'ocr' instead.",
             inputSchema: schema(
                 properties: [
                     "x": .object(["type": .array([.string("integer"), .string("string")])]),

--- a/Tests/MacControlMCPTests/GroundingCoordinateTests.swift
+++ b/Tests/MacControlMCPTests/GroundingCoordinateTests.swift
@@ -1,0 +1,89 @@
+import Testing
+import CoreGraphics
+@testable import MacControlMCP
+
+/// Regression tests for the Retina coordinate bug in GroundingController.
+///
+/// `ScreenController.ocr` returns block coordinates in image PIXELS. On a
+/// 2× Retina display a full-screen capture is twice the point size, so an
+/// OCR center used as a click target (`ground`) or compared against AX
+/// frames (`axTreeAugmented`, which are in points) is 2× off unless it is
+/// first divided by the backing scale. `ocrPixelCenterToPoints` is the
+/// pure conversion; these tests pin its math without needing a display.
+@Suite("Grounding OCR pixel→point conversion")
+struct GroundingCoordinateTests {
+
+    @Test("2× Retina capture halves the OCR center into points")
+    func retinaHalves() {
+        // 1512×982 pt display captured at 3024×1964 px (scale 2.0).
+        // Block origin (600,400) size (40,20) → pixel center (620,410)
+        // → point (310,205).
+        let p = GroundingController.ocrPixelCenterToPoints(
+            blockX: 600, blockY: 400, blockW: 40, blockH: 20,
+            imagePixelWidth: 3024, imagePixelHeight: 1964,
+            displayPointWidth: 1512, displayPointHeight: 982
+        )
+        #expect(abs(p.x - 310) < 0.0001)
+        #expect(abs(p.y - 205) < 0.0001)
+    }
+
+    @Test("1× display is identity (points == pixels)")
+    func nonRetinaIdentity() {
+        // 1440×900 pt display captured at 1440×900 px (scale 1.0).
+        // Block origin (100,50) size (40,20) → center (120,60).
+        let p = GroundingController.ocrPixelCenterToPoints(
+            blockX: 100, blockY: 50, blockW: 40, blockH: 20,
+            imagePixelWidth: 1440, imagePixelHeight: 900,
+            displayPointWidth: 1440, displayPointHeight: 900
+        )
+        #expect(abs(p.x - 120) < 0.0001)
+        #expect(abs(p.y - 60) < 0.0001)
+    }
+
+    @Test("fractional scaled mode converts exactly")
+    func fractionalScale() {
+        // A "looks like 1710×1112" scaled mode on a 3456×2234 px panel.
+        // scaleX = 1710/3456, scaleY = 1112/2234.
+        let p = GroundingController.ocrPixelCenterToPoints(
+            blockX: 3456, blockY: 2234, blockW: 0, blockH: 0,
+            imagePixelWidth: 3456, imagePixelHeight: 2234,
+            displayPointWidth: 1710, displayPointHeight: 1112
+        )
+        #expect(abs(p.x - 1710) < 0.0001)
+        #expect(abs(p.y - 1112) < 0.0001)
+    }
+
+    @Test("zero image dimensions fall back to identity, no divide-by-zero")
+    func zeroDimsSafe() {
+        let p = GroundingController.ocrPixelCenterToPoints(
+            blockX: 10, blockY: 10, blockW: 0, blockH: 0,
+            imagePixelWidth: 0, imagePixelHeight: 0,
+            displayPointWidth: 100, displayPointHeight: 100
+        )
+        #expect(p.x == 10)
+        #expect(p.y == 10)
+    }
+
+    /// This is the AX-tree join bug made concrete: an AX button frame lives
+    /// in points; its label's raw OCR pixel-center falls OUTSIDE that frame
+    /// on Retina, so the pre-fix `rect.contains(pixelCenter)` join misses
+    /// it. After conversion the point-center lands inside and the join
+    /// succeeds.
+    @Test("AX-frame geometric join matches only after pixel→point conversion")
+    func axJoinMatchesAfterConversion() {
+        // AX frame for a small button, in points.
+        let axRect = CGRect(x: 100, y: 100, width: 100, height: 40)
+
+        // OCR reports the button's label centered at pixel (300, 240),
+        // which is point (150, 120) on a 2× capture — inside axRect.
+        let rawPixelCenter = CGPoint(x: 300, y: 240)
+        #expect(!axRect.contains(rawPixelCenter))   // pre-fix: join misses
+
+        let pointCenter = GroundingController.ocrPixelCenterToPoints(
+            blockX: 300, blockY: 240, blockW: 0, blockH: 0,
+            imagePixelWidth: 3024, imagePixelHeight: 1964,
+            displayPointWidth: 1512, displayPointHeight: 982
+        )
+        #expect(axRect.contains(pointCenter))       // post-fix: join hits
+    }
+}


### PR DESCRIPTION
## Retina grounding fix — OCR coordinates were 2× off (pixel vs point space)

Two HIGH grounding bugs on Retina displays, plus a documentation follow-up surfaced by adversarial verification.

### Root cause
`ScreenController.ocr()` emits OCR block coordinates in **image pixels**: `CGDisplayCreateImage` captures at backing resolution, so on a 2× Retina display a full-screen capture is 3024×1964px for a 1512×982pt display, and Vision's normalized boxes are multiplied by those pixel dims. AX frames (`kAXPositionAttribute`) and the click tools are in **points**. Two grounding paths mixed the two:

- **`ground()` OCR fallback** returned the pixel center as the **click target** → 2× off (usually off-screen) on Retina.
- **`axTreeAugmented()` geometric join** compared pixel OCR centers against point-space AX rects → small element rects never contained the 2×-too-large center, so only oversized containers matched and no useful label was inferred. The whole augmentation was **silently broken on Retina**.

Coincidentally correct on a 1× display (scale 1.0), which is why it wasn't caught earlier.

### Fix
A pure, testable `GroundingController.ocrPixelCenterToPoints(...)` scales an OCR block center from captured-image-pixel space into global screen points using the actual image dims vs `CGDisplayBounds(main)` point dims. It's exact for any backing factor (2.0 or fractional scaled modes), identity on 1×, and divide-by-zero-safe. Applied at both sites; the AX path and all non-OCR behavior are unchanged.

Second commit (docs only): `ocr_screen` / `OCRBlock` now **document** that their coords are image-pixel space and point to `ground` for click-ready points — closing the same 2×-off footgun via a sibling tool without changing behavior.

### Not a bug (withdrawn)
`ScreenCaptureKitBridge` was flagged earlier as a sibling coordinate bug; on inspection it only *sizes* the capture (correctly, via the containing screen's backing scale) and returns a bare CGImage — it emits no coordinate, so there's nothing to fix.

### Verification
- **5 new deterministic tests** pin the transform (2× Retina, 1× identity, fractional scale, divide-by-zero, and one that reproduces the AX-join `contains` miss pre-fix / hit post-fix). No display required.
- **Full suite green: 183/183.**
- **Adversarial 3-lens review** (independent agents), all clean:
  - *Double-correction:* no caller of `ground()`/`axTreeAugmented()` applies a second scale/offset — the click path posts CGPoints directly in point space (`callGround`/`callAXTreeAugmented` → `MouseController`/`AccessibilityController`). The fix corrects exactly once.
  - *Scale-source:* capture is always the main display; pixel denominator and point numerator come from the same path; positive uniform scale, no re-flip.
  - *`ocr_screen` scope:* its pixels are correct for their image-annotation purpose — not the grounding bug — but were undocumented (addressed by the docs commit).

### On-device note
The live `mcp__mac-control-mcp__*` tools run the installed signed binary, not this working tree — so a real capture-and-click won't exercise this fix until the binary is rebuilt/reinstalled. The transform itself is pinned by the unit tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
